### PR TITLE
Turns createApps and command center setup synchronous

### DIFF
--- a/lib/app/Readme.md
+++ b/lib/app/Readme.md
@@ -8,12 +8,12 @@ In your configuration, you can enable an app using something like this:
 
 ```yaml
 apps:
-    # Replace appName with the name of the app you wish to enable
-    appName:
-        responseCache: 180
-        disabled: false
+  # Replace appName with the name of the app you wish to enable
+  appName:
+    responseCache: 180
+    disabled: false
 ```
 
-* `appName` (mandatory) This is the name of the app you wish to enable.
-* `responseCache` (optional) Number of seconds usercommand responses should be cached for. (default: 3 mins)
-* `disabled` (optional) This will determine if the app gets exposed at all. (default: true)
+* `appName` (string; mandatory) This is the name of the app you wish to enable.
+* `responseCache` (number; optional) Number of seconds usercommand responses should be cached for. (default: 3 mins)
+* `disabled` (boolean; optional) This will determine if the app gets exposed at all. (default: true)

--- a/lib/app/index.js
+++ b/lib/app/index.js
@@ -1,53 +1,180 @@
-var async = require('async');
+'use strict';
 
-var mage = require('../mage');
-var logger = mage.core.logger;
+/** @module app */
+
+const memoize = require('memoizee');
 
 
 // app registration
 
-var appMap = {};
-var appList = [];
+const appMap = {};
+const appList = [];
 
 
 /**
- * This function creates instances of all configured apps and registers them into appMap and appList.
+ * Returns the configuration for all apps (overridden during unit tests)
+ *
+ * @returns {Object}
  */
+/* istanbul ignore next */
+exports.getAppsConfig = memoize(function () {
+	return require('lib/mage').core.config.get(['apps']);
+});
 
-exports.createApps = function (cb) {
-	var appsConfig = mage.core.config.get(['apps']);
+/**
+ * Returns a logger (overridden during unit tests)
+ *
+ * @returns {Object}
+ */
+/* istanbul ignore next */
+exports.getLogger = memoize(function () {
+	return require('lib/mage').core.logger;
+});
 
-	var appNames = Object.keys(appsConfig);
+/**
+ * Creates and returns a CommandCenter instance for the given app (overridden during unit tests)
+ *
+ * @returns {Object}
+ */
+/* istanbul ignore next */
+exports.createCommandCenter = function (app) {
+	const CommandCenter = require('lib/mage').core.cmd.CommandCenter;
+	return new CommandCenter(app);
+};
 
-	async.eachLimit(appNames, 5, function (appName, callback) {
-		var appConfig = appsConfig[appName];
 
-		if (!appConfig || appConfig.disabled) {
-			logger.debug('Not creating app:', appName, appConfig ? '(disabled)' : '(no configuration found)');
-			return setImmediate(callback);
+/**
+ * @classdesc App
+ */
+class App {
+	/**
+	 * @constructor
+	 * @param {string} name     The name of the application
+	 * @param {Object} config   The application configuration
+	 */
+	constructor(name, config) {
+		this.name = name;
+		this.config = config || {};
+		this.commandCenter = exports.createCommandCenter(this);
+	}
+
+	/**
+	 * Sets up the command center for this app
+	 */
+	setup() {
+		this.commandCenter.setup();
+	}
+}
+
+
+/**
+ * Creates an instance of a configured app and registers it into appMap and appList
+ *
+ * @param {string} name  The name of the application
+ * @returns {Object}     The created application
+ * @throws {Error}       If the app by the given name is not configured to exist or has already been created
+ */
+exports.createApp = function (name) {
+	const logger = exports.getLogger();
+	logger.debug('Creating app:', name);
+
+	const appsConfig = exports.getAppsConfig();
+	if (!appsConfig.hasOwnProperty(name)) {
+		throw new Error(`App "${name}" has not been configured`);
+	}
+
+	if (appMap[name]) {
+		throw new Error(`App "${name}" has already been created`);
+	}
+
+	const app = new App(name, appsConfig[name]);
+	app.setup();
+
+	appMap[name] = app;
+	appList.push(app);
+
+	return app;
+};
+
+
+/**
+ * Creates instances of all configured apps and registers them into appMap and appList.
+ */
+exports.createApps = function () {
+	const logger = exports.getLogger();
+	const appsConfig = exports.getAppsConfig();
+
+	const appNames = Object.keys(appsConfig);
+	for (const appName of appNames) {
+		const appConfig = appsConfig[appName];
+
+		if (appMap[appName]) {
+			logger.debug(`Not creating app "${appName}" (already created)`);
+			continue;
 		}
 
-		logger.debug('Creating app:', appName);
+		if (!appConfig) {
+			logger.debug(`Not creating app "${appName}" (no configuration found)`);
+			continue;
+		}
 
-		var app = {
-			name: appName,
-			config: appConfig,
-			commandCenter: null
-		};
+		if (appConfig.disabled) {
+			logger.debug(`Not creating app "${appName}" (disabled)`);
+			continue;
+		}
 
-		app.commandCenter = new mage.core.cmd.CommandCenter(app);
+		exports.createApp(appName);
+	}
+};
 
-		app.commandCenter.setup(function (error) {
-			if (error) {
-				return callback(error);
-			}
 
-			appMap[appName] = app;
-			appList.push(app);
+/**
+ * Returns true if the app has been created, false otherwise
+ *
+ * @param {string} name  The name of the application
+ * @returns {boolean}
+ * @throws {Error}       If the app by the given name is not configured to exist
+ */
+exports.isAppCreated = function (name) {
+	const appsConfig = exports.getAppsConfig();
+	if (!appsConfig.hasOwnProperty(name)) {
+		throw new Error(`App "${name}" has not been configured`);
+	}
 
-			callback();
-		});
-	}, cb);
+	// If the app has been set up, it exists in the appMap
+
+	return appMap.hasOwnProperty(name);
+};
+
+
+/**
+ * Removes an app from the list of known apps. This is mostly useful for unit testing.
+ *
+ * @param {string} name  The name of the application
+ * @throws {Error}       If an application with the given name was not found
+ */
+exports.removeApp = function (name) {
+	const app = appMap[name];
+	if (!app) {
+		throw new Error(`App "${name}" does not exist or has not yet been set up`);
+	}
+
+	delete appMap[name];
+	const index = appList.indexOf(app);
+	if (index !== -1) {
+		appList.splice(index, 1);
+	}
+};
+
+
+/**
+ * Removes all apps from the list of known apps. This is mostly useful for unit testing.
+ */
+exports.removeAllApps = function () {
+	const apps = exports.getAppList();
+	for (const app of apps) {
+		exports.removeApp(app.name);
+	}
 };
 
 
@@ -57,7 +184,6 @@ exports.createApps = function (cb) {
  * @param {string} name The name of the app
  * @returns {Object}
  */
-
 exports.get = function (name) {
 	return appMap[name];
 };
@@ -66,11 +192,10 @@ exports.get = function (name) {
 /**
  * Returns all app instances in a list
  *
- * @returns {Array} All app instances
+ * @returns {Object[]} All app instances
  */
-
 exports.getAppList = function () {
-	return appList;
+	return appList.slice();
 };
 
 
@@ -79,15 +204,6 @@ exports.getAppList = function () {
  *
  * @returns {Object} All app instances
  */
-
 exports.getAppMap = function () {
 	return appMap;
-};
-
-
-exports.getPublicConfig = function (baseUrl, app) {
-	return {
-		url: baseUrl + '/app/' + app.name,
-		cors: mage.core.httpServer.getCorsConfig()
-	};
 };

--- a/lib/commandCenter/commandCenter.js
+++ b/lib/commandCenter/commandCenter.js
@@ -1,51 +1,55 @@
-var async = require('async');
-var zlib = require('zlib');
-var fs = require('fs');
-var path = require('path');
-var util = require('util');
-var functionArguments = require('function-arguments');
+'use strict';
 
-var EventEmitter = require('events').EventEmitter;
-var ResponseCache = require('./responseCache').ResponseCache;
-var httpBatchHandler = require('./httpBatchHandler');
+const async = require('async');
+const zlib = require('zlib');
+const fs = require('fs');
+const path = require('path');
+const functionArguments = require('function-arguments');
 
-var mage;
-var logger;
-var State;
+const EventEmitter = require('events').EventEmitter;
+const ResponseCache = require('./responseCache').ResponseCache;
+const httpBatchHandler = require('./httpBatchHandler');
 
-var DEFAULT_RESPONSE_CACHE_TTL = 3 * 60;  // cache lifetime of the command response in seconds
-var COMPRESSION_THRESHOLD = 4096;         // only gzip if the response is at least this many bytes uncompressed
-var COMMANDS_DIR_NAME = 'usercommands';     // user command directory inside of module file space
-var COMMAND_PATH_SPLITTER = '.';                // what separates the module name and command name
-var CONTENT_TYPE_JSON = 'application/json; charset=UTF-8';
+let mage;
+let logger;
+let State;
+
+const DEFAULT_RESPONSE_CACHE_TTL = 3 * 60;  // cache lifetime of the command response in seconds
+const COMPRESSION_THRESHOLD = 4096;         // only gzip if the response is at least this many bytes uncompressed
+const COMMANDS_DIR_NAME = 'usercommands';     // user command directory inside of module file space
+const COMMAND_PATH_SPLITTER = '.';                // what separates the module name and command name
+const CONTENT_TYPE_JSON = 'application/json; charset=UTF-8';
 
 exports = module.exports = new EventEmitter();
 
-function UserCommandSetupError(message, details) {
-	Error.captureStackTrace(this, this.constructor);
-	Object.assign(this, details);
-
-	this.message = message;
-	this.name = 'UserCommandSetupError';
+class UserCommandSetupError extends Error {
+	constructor(message, details) {
+		super(message);
+		Object.assign(this, details);
+		this.name = 'UserCommandSetupError';
+	}
 };
 
-util.inherits(UserCommandSetupError, Error);
 
 // message hooks
 
-var messageHooks = [];
+const messageHooks = [];
 
 exports.registerMessageHook = function (name, required, fn) {
 	if (typeof name !== 'string') {
-		throw new Error('Message hook name must be of type "string"');
+		throw new TypeError('Message hook name must be of type "string"');
 	}
 
 	if (typeof required !== 'boolean') {
-		throw new Error('Message hook "required" argument must be of type "boolean"');
+		throw new TypeError('Message hook "required" argument must be of type "boolean"');
 	}
 
 	if (typeof fn !== 'function') {
-		throw new Error('Message hook function must be of type "function"');
+		throw new TypeError('Message hook function must be of type "function"');
+	}
+
+	if (fn.length !== 4) {
+		throw new TypeError('Message hook function must take 4 arguments: (state, data, batch, cb)');
 	}
 
 	messageHooks.push({ name: name, required: required, fn: fn });
@@ -55,15 +59,15 @@ exports.registerMessageHook = function (name, required, fn) {
 /**
  * To allow flexibility for testing, some objects are passed in with initialize.
  *
- * @param {Object}   mageInstance A mage instance.
- * @param {Object}   mageLogger   A mage logger.
- * @param {Function} State        The state constructor.
+ * @param {Object}   mageInstance      A mage instance.
+ * @param {Object}   mageLogger        A mage logger.
+ * @param {Function} StateConstructor  The State class constructor.
  */
 
-exports.initialize = function (mageInstance, mageLogger, stateConstructor) {
+exports.initialize = function (mageInstance, mageLogger, StateConstructor) {
 	mage = mageInstance;
 	logger = mageLogger;
-	State = stateConstructor;
+	State = StateConstructor;
 
 	httpBatchHandler.setup(mageInstance, mageLogger);
 };
@@ -77,7 +81,7 @@ function CommandCenter(app) {
 	this.commands = {};
 	this.userCommandTimeout = null;
 
-	var ttl;
+	let ttl;
 
 	if (app.config && app.config.hasOwnProperty('responseCache')) {
 		ttl = app.config.responseCache;
@@ -91,12 +95,19 @@ function CommandCenter(app) {
 exports.CommandCenter = CommandCenter;
 
 
-CommandCenter.prototype.setupUserCommand = function (modName, cmdFile) {
-	var modPath = mage.getModulePath(modName);
-	var cmdPath = modPath + '/' + COMMANDS_DIR_NAME + '/' + cmdFile;
+/**
+ * Registers a user command from disk
+ *
+ * @throws {Error}           In the case of disk error or if user command setup failed
+ * @param {string} modName   The name of the module
+ * @param {string} modName   The path to the module
+ * @param {string} cmdFile   The name of the file or folder containing the user command.
+ */
+CommandCenter.prototype.setupUserCommandFromDisk = function (modName, modPath, cmdFile) {
+	const cmdPath = modPath + '/' + COMMANDS_DIR_NAME + '/' + cmdFile;
 
 	if (path.extname(cmdFile) !== '.js') {
-		var stats = fs.statSync(cmdPath);
+		const stats = fs.statSync(cmdPath);
 
 		if (!stats.isDirectory()) {
 			// file is not a directory, nor a .js file, so ignore
@@ -105,8 +116,8 @@ CommandCenter.prototype.setupUserCommand = function (modName, cmdFile) {
 		}
 	}
 
-	var cmdName = path.basename(cmdFile, '.js');
-	var details = {
+	const cmdName = path.basename(cmdFile, '.js');
+	const logDetails = {
 		module: {
 			path: cmdPath,
 			name: modName,
@@ -115,174 +126,183 @@ CommandCenter.prototype.setupUserCommand = function (modName, cmdFile) {
 	};
 
 	// Load user command file
-	var cmd;
+	let cmd;
 
 	try {
 		cmd = require(cmdPath);  // require() may throw, which we like in this case
 	} catch (requireError) {
 		// Add the error stack to the details
-		var stackInfo = requireError.stack.split('\n');
+		const stackInfo = requireError.stack.split('\n');
 		stackInfo.shift();
-		details.module.stack = stackInfo.map(function (line) {
+		logDetails.module.stack = stackInfo.map(function (line) {
 			return line.substring(7);
 		});
 
 		// Wrap the error
-		var error = new UserCommandSetupError('Failed to load user command: ' + requireError.message, details);
-		throw error;
+		throw new UserCommandSetupError(`Failed to load user command: ${requireError.message}`, logDetails);
 	}
 
-	var execPath = modName + COMMAND_PATH_SPLITTER + cmdName;
+	this.setupUserCommand(modName, cmdName, cmd);
+};
 
 
+/**
+ * Registers a user command
+ *
+ * @throws {Error}           If user command setup failed
+ * @param {string} modName   The name of the registered module
+ * @param {string} cmdName   The name of the user command
+ * @param {Object} cmd       The full user command implementation (ie: the result of calling require(userCommandFile))
+ */
+CommandCenter.prototype.setupUserCommand = function (modName, cmdName, cmd) {
+	const logDetails = {
+		module: {
+			name: modName,
+			command: cmdName
+		}
+	};
 
-	// To avoid really long lines we assign this to a variable.
+	if (typeof modName !== 'string') {
+		throw new UserCommandSetupError('Module name must be a string', logDetails);
+	}
+
+	if (typeof cmdName !== 'string') {
+		throw new UserCommandSetupError('Command name must be a string', logDetails);
+	}
+
+	if (!cmd || typeof cmd !== 'object') {
+		throw new UserCommandSetupError('Command must be an object', logDetails);
+	}
+
 	if (typeof cmd.execute !== 'function') {
-		throw new UserCommandSetupError('Command has no "execute" function', details);
+		throw new UserCommandSetupError('Command has no "execute" function', logDetails);
 	}
 
 	// acl is optional (no one can access on undefined), however when there is one, it has to be an array.
 	if (cmd.acl && !Array.isArray(cmd.acl)) {
-		throw new UserCommandSetupError('acl configuration must be an array', details);
+		throw new UserCommandSetupError('acl configuration must be an array', logDetails);
 	}
 
 	// Is command async?
-	cmd.isAsync = Object.getPrototypeOf(cmd.execute)[Symbol.toStringTag] === 'AsyncFunction';
+	const isAsync = Object.getPrototypeOf(cmd.execute)[Symbol.toStringTag] === 'AsyncFunction';
 
 	// Legacy warning
 	if (cmd.params) {
 		logger.warning
-			.data(details)
+			.data(logDetails)
 			.log('You no longer need to specify params in your user commands');
 	}
 
 	// Parameters extraction
-	var params = functionArguments(cmd.execute);
-	var firstParameter = params.shift();
+	const params = functionArguments(cmd.execute);
+	const firstParameter = params.shift();
 
 	// Sanity check
 	if (firstParameter !== 'state') {
-		throw new UserCommandSetupError('execute function\'s first parameter must be "state"', details);
+		throw new UserCommandSetupError('execute()\'s first argument must be "state"', logDetails);
 	}
 
-	if (!cmd.isAsync) {
-		var lastParameter = params.pop();
+	if (!isAsync) {
+		const lastParameter = params.pop();
 		if (lastParameter !== 'cb' && lastParameter !== 'callback') {
-			throw new UserCommandSetupError('execute function\'s last parameter must be "cb" or "callback\"', details);
+			throw new UserCommandSetupError(
+				'execute() must be async or its last argument must be "cb" or "callback"',
+				logDetails
+			);
 		}
 	}
 
-	// Parameters injection
-	cmd.params = params;
+	// Register the user command
+	const execPath = `${modName}${COMMAND_PATH_SPLITTER}${cmdName}`;
 
-	logger.verbose('Exposing command', execPath, 'at', cmdPath);
+	logger.verbose('Exposing command', execPath);
 
 	this.commands[execPath] = {
 		execPath: execPath,
 		gameModule: modName,
 		cmdName: cmdName,
 		cmdPathSplitter: COMMAND_PATH_SPLITTER,
-		mod: cmd
+		mod: cmd,
+		params: params,
+		isAsync: isAsync
 	};
 };
 
-CommandCenter.prototype.setupMod = function (modName, cb) {
-	var modPath = mage.getModulePath(modName);
+
+/**
+ * Sets up a module's user commands based on its location on disk
+ *
+ * @throws {Error}           In the case of disk error or if user command setup failed
+ * @param {string} modName   The name of the registered module
+ */
+CommandCenter.prototype.setupMod = function (modName) {
+	const modPath = mage.getModulePath(modName);
 
 	if (!modPath) {
-		return setImmediate(function () {
-			cb(new Error('Could not resolve path of module "' + modName + '".'));
-		});
+		throw new Error(`Could not resolve path of module "${modName}"`);
 	}
 
-	var that = this;
+	let files;
 
-	fs.readdir(modPath + '/' + COMMANDS_DIR_NAME, function (error, files) {
-		if (error) {
-			if (error.code === 'ENOENT') {
-				// no user commands in this module
-				return cb();
-			}
-
-			return cb(error);
+	try {
+		files = fs.readdirSync(modPath + '/' + COMMANDS_DIR_NAME);
+	} catch (error) {
+		if (error.code === 'ENOENT') {
+			// no user commands in this module
+			return;
 		}
 
-		for (var i = 0; i < files.length; i += 1) {
-			try {
-				that.setupUserCommand(modName, files[i]);
-			} catch (e) {
-				return cb(e);
-			}
-		}
+		throw error;
+	}
 
-		cb();
-	});
+	for (const cmdFile of files) {
+		this.setupUserCommandFromDisk(modName, modPath, cmdFile);
+	}
 };
 
 
-// The setup function will make a set of commands available for execution.
-
-CommandCenter.prototype.setup = function (cb) {
+/**
+ * Make all user commands in this command center available for execution
+ *
+ * @throws {Error}   If the command center instance has already been setup or if user command setup failed
+ */
+CommandCenter.prototype.setup = function () {
 	if (this.exposed) {
-		return cb(new Error('The "' + this.app.name + '" command center has already been exposed.'));
+		throw new Error(`The "${this.app.name}" command center has already been exposed`);
 	}
 
 	logger.verbose('Exposing commands for app:', this.app.name);
 
-	var modNames = mage.listModules();
-	var that = this;
-
-	async.eachLimit(modNames, 5, function (modName, callback) {
-		that.setupMod(modName, callback);
-	}, function (error) {
-		if (error) {
-			return cb(error);
-		}
-
-		logger.notice('Exposed usercommands for app:', that.app.name);
-
-		httpBatchHandler.register(that);
-
-		that.exposed = true;
-
-		cb();
-	});
-};
-
-/**
- * Return the list of the commands provided by the given module.
- *
- * @param   {string}    modName   The name of the module, you want to get the list of function
- * @returns {Object}    List of commands
- */
-
-CommandCenter.prototype.getModuleCommands = function (modName) {
-	var result = {};
-
-	for (var cmdPath in this.commands) {
-		var parts = cmdPath.split(COMMAND_PATH_SPLITTER);
-
-		if (modName === parts[0]) {
-			result[parts[1]] = this.commands[cmdPath];
-		}
+	const modNames = mage.listModules();
+	for (const modName of modNames) {
+		this.setupMod(modName);
 	}
 
-	return result;
+	logger.notice('Exposed usercommands for app:', this.app.name);
+
+	httpBatchHandler.register(this);
+
+	this.exposed = true;
 };
 
 
+/**
+ * Returns the configuration for an app's client
+ *
+ * @param {string} baseUrl
+ * @returns {Object}
+ */
 CommandCenter.prototype.getPublicConfig = function (baseUrl) {
-	var cfg = {
+	const cfg = {
 		url: baseUrl + '/' + this.app.name,
 		cors: mage.core.httpServer.getCorsConfig(),
 		timeout: 15000,
 		commands: {}
 	};
 
-	var execPaths = Object.keys(this.commands);
-	for (var i = 0; i < execPaths.length; i += 1) {
-		var execPath = execPaths[i];
-		var cmd = this.commands[execPath];
+	const execPaths = Object.keys(this.commands);
+	for (const execPath of execPaths) {
+		const cmd = this.commands[execPath];
 
 		if (!cfg.commands[cmd.gameModule]) {
 			cfg.commands[cmd.gameModule] = [];
@@ -290,7 +310,7 @@ CommandCenter.prototype.getPublicConfig = function (baseUrl) {
 
 		cfg.commands[cmd.gameModule].push({
 			name: cmd.cmdName,
-			params: cmd.mod.params
+			params: cmd.params
 		});
 	}
 
@@ -308,7 +328,7 @@ CommandCenter.prototype.getPublicConfig = function (baseUrl) {
  * @returns {string}                   The serialized response.
  */
 function serializeCommandResult(result) {
-	var out = [];
+	const out = [];
 
 	out.push(result.errorCode || 'null');
 	out.push(result.response || 'null');
@@ -339,9 +359,8 @@ function shouldCompress(content, acceptedEncodings) {
  * @param {string|Buffer} content
  * @param {Function} cb
  */
-
 function compress(content, cb) {
-	var startTime = process.hrtime();
+	const startTime = process.hrtime();
 
 	zlib.gzip(content, function (error, buf) {
 		if (error) {
@@ -349,8 +368,8 @@ function compress(content, cb) {
 			return cb(error);
 		}
 
-		var durationRaw = process.hrtime(startTime);
-		var duration = durationRaw[0] + durationRaw[1] / 1e9;
+		const durationRaw = process.hrtime(startTime);
+		const duration = durationRaw[0] + durationRaw[1] / 1e9;
 
 		logger.debug(
 			'Gzipped command batch response of', content.length, 'chars down to',
@@ -362,17 +381,21 @@ function compress(content, cb) {
 }
 
 
+/**
+ * Sets the execution timeout of all user commands to the given duration
+ *
+ * @param {number} timeout   Timeout in milliseconds
+ */
 CommandCenter.prototype.setUserCommandTimeout = function (timeout) {
 	this.userCommandTimeout = timeout;
 };
 
 /**
- * Return the information about the given command, or undefined if it does not exist.
+ * Returns the information about the given command, or undefined if it does not exist.
  *
- * @param   {string}    cmdName       Name of the command
- * @returns {Object}    Command information
+ * @param {string} cmdName  Name of the command
+ * @returns {Object}        Command information
  */
-
 CommandCenter.prototype.getCommandInfo = function (cmdName) {
 	return this.commands[cmdName];
 };
@@ -383,37 +406,44 @@ CommandCenter.prototype.getCommandInfo = function (cmdName) {
  * If the given params are an Object, the object will be filtered to keep only
  * the fields with the key specified in the user module.
  *
- * If the params are an Array, the missing parameters will be added with undefined as value.
- * So that the built parameter list will have the expected length.
- * If two many parameters are provided, an exception will be thrown.
+ * If the params are an Array, the missing parameters will be added with undefined as value,
+ * so that the built parameter list will have the expected length.
+ * If too many parameters are provided, an exception will be thrown.
  *
- * @param {string[]}    cmdInfoModParams  Parameters information from the user module
- * @param {Object}      cmdParams         Parameters to pass to the user command function
- * @returns {Array}     Built parameter list
- * @throws  {Error}     Will throw an error if there are too many parameters provided.
+ * @throws {Error}                     Will throw an error if there are too many parameters provided.
+ * @param {string[]} cmdInfoModParams  Parameters information from the module's user command
+ * @param {Object} cmdParams           Parameter values to pass to the user command function (may be mutated)
+ * @returns {mixed[]}                  Built parameter value array
  */
 CommandCenter.prototype.buildParamList = function (cmdInfoModParams, cmdParams) {
-	if (!cmdInfoModParams) {
-		return [];
+	if (!Array.isArray(cmdInfoModParams)) {
+		throw new TypeError('No command parameters array configured.');
 	}
-
-	var paramList = [];
 
 	if (Array.isArray(cmdParams)) {
-		if (cmdParams.length  >  cmdInfoModParams.length) {
+		if (cmdParams.length > cmdInfoModParams.length) {
 			throw new Error('Too many parameters provided.');
 		}
-		paramList = cmdParams;
-		while (paramList.length < cmdInfoModParams.length) {
-			paramList.push(undefined);
+
+		const result = cmdParams.slice();
+
+		while (result.length < cmdInfoModParams.length) {
+			result.push(undefined);
 		}
-	} else {
-		for (var i = 0; i < cmdInfoModParams.length; i++) {
-			paramList.push(cmdParams[cmdInfoModParams[i]]);
-		}
+		return result;
 	}
 
-	return paramList;
+	if (cmdParams && typeof cmdParams === 'object') {
+		const result = [];
+
+		for (const paramName of cmdInfoModParams) {
+			result.push(cmdParams[paramName]);
+		}
+
+		return result;
+	}
+
+	throw new TypeError('Command did not receive an array or object of arguments.');
 };
 
 
@@ -429,7 +459,6 @@ CommandCenter.prototype.buildParamList = function (cmdInfoModParams, cmdParams) 
  * @param {Object}   [metaData] Optional meta data that will be merged into state.data.
  * @param {Function} cb
  */
-
 CommandCenter.prototype.executeCommand = function (cmd, session, metaData, cb) {
 	var cmdInfo = this.getCommandInfo(cmd.name);
 	if (!cmdInfo) {
@@ -459,7 +488,7 @@ CommandCenter.prototype.executeCommand = function (cmd, session, metaData, cb) {
 		state.data = metaData;
 	}
 
-	// check if access control list have the proper access
+	// check if access control list grants the proper access
 	if (!state.canAccess(cmdInfo.mod.acl)) {
 		var errorText = 'User command access level not satisfied for command "' + cmd.name +
 			'" on app "' + this.app.name + '".';
@@ -494,7 +523,7 @@ CommandCenter.prototype.executeCommand = function (cmd, session, metaData, cb) {
 		var paramList;
 
 		try {
-			paramList = that.buildParamList(mod.params, cmd.params);
+			paramList = that.buildParamList(cmdInfo.params, cmd.params);
 		} catch (err) {
 			return cb(err);
 		}
@@ -534,7 +563,7 @@ CommandCenter.prototype.executeCommand = function (cmd, session, metaData, cb) {
 			});
 		}
 
-		if (mod.isAsync) {
+		if (cmdInfo.isAsync) {
 			mod.execute.apply(mod, paramList).then(function (response) {
 				state.respond(response, mod.serialize === false);
 			}).catch(function (error) {
@@ -562,7 +591,6 @@ CommandCenter.prototype.executeCommand = function (cmd, session, metaData, cb) {
  * @param {string[]} batch.commandNames   Array of all command names in the batch, in order.
  * @param {Function} cb                   Callback on completion.
  */
-
 function processBatchHeader(state, batch, cb) {
 	if (messageHooks.length === 0) {
 		return cb();
@@ -616,7 +644,6 @@ function processBatchHeader(state, batch, cb) {
  * @param {Object}   [metaData]         Optional meta data that will be merged into state.data.
  * @param {Function} transportCb        A callback to the transport that takes content and meta data.
  */
-
 CommandCenter.prototype.executeBatch = function (acceptedEncodings, batch, queryId, metaData, transportCb) {
 	var that = this;
 	var startTime = process.hrtime();

--- a/lib/httpServer/transports/http/index.js
+++ b/lib/httpServer/transports/http/index.js
@@ -57,24 +57,28 @@ exports.setCorsConfig = function (config) {
 };
 
 
-exports.expose = function (config) {
-	if (config) {
-		if (typeof config === 'object') {
-			config = url.format({
-				protocol: config.protocol || 'http',
-				hostname: config.host || 'localhost',
-				port: config.port || undefined,
-				auth: (config.authUser && config.authPass) ? config.authUser + ':' + config.authPass : undefined,
-				pathname: config.path || undefined
-			});
-		}
+exports.expose = function (url) {
+	if (url === null || url === undefined) {
+		// If no base URL has been configured, a relative path can be used client-side.
+		// This is good enough for web apps that are hosted by the MAGE server itself.
+		// In that case, we return empty string, because can be safely concatenated with
+		// paths.
 
-		if (typeof config !== 'string') {
-			throw new TypeError('Expose URL is not a string: ' + config);
-		}
+		expose = '';
+		return;
 	}
 
-	expose = config;
+	if (typeof url !== 'string') {
+		throw new TypeError('Expose URL is not a string: ' + url);
+	}
+
+	// drop trailing slashes (for later path concatenation)
+
+	while (url.slice(-1) === '/') {
+		url = url.slice(0, -1);
+	}
+
+	expose = url;
 };
 
 
@@ -983,31 +987,7 @@ exports.getCorsConfig = function () {
 };
 
 
-exports.getBaseUrl = function (headers) {
-	if (!expose && headers && headers.host) {
-		// Use the host header to generate a string
-
-		expose = url.format({
-			protocol: 'http',
-			host: headers.host
-		});
-	}
-
-	// If nothing has been configured, and no headers were passed, the base URL will have to be
-	// guessed. Alternatively, a relative path combined with a URL somewhere can be constructed.
-	// We return empty string, because it's falsy and still can be safely concatenated with
-	// paths.
-
-	if (!expose) {
-		return '';
-	}
-
-	// drop trailing slashes
-
-	while (expose.slice(-1) === '/') {
-		expose = expose.slice(0, -1);
-	}
-
+exports.getBaseUrl = function () {
 	return expose;
 };
 

--- a/lib/mage/Mage.js
+++ b/lib/mage/Mage.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var EventEmitter = require('events').EventEmitter;
 var fs = require('fs');
 var util = require('util');
@@ -661,37 +663,26 @@ Mage.prototype.isDevelopmentMode = function (feature) {
 };
 
 
-Mage.prototype.getClientConfig = function (appName, baseUrl) {
+Mage.prototype.getClientConfig = function (appName) {
 	// We construct a mageConfig object from our app's configuration. These
 	// are the core app config bits that need to make it into every build.
 	// The app's URLs need to be hard coded into the build so the app knows
 	// which server to connect to.
 
-	var app = this.core.app.get(appName);
+	const baseUrl = this.core.httpServer.getBaseUrl();
+	const app = this.core.app.isAppCreated(appName) ? this.core.app.get(appName) : this.core.app.createApp(appName);
 
-	if (!app) {
-		throw new Error('App not found: ' + appName);
-	}
-
-	var config = {
+	return {
 		appName: app.name,
-		appConfig: {},
 		appVersion: this.rootPackage.version,
-		appVariants: {
-			languages: app.languages,
-			densities: app.densities
-		},
 		server: {
 			baseUrl: baseUrl,
-			app: this.core.app.getPublicConfig(baseUrl, app),
 			msgStream: this.core.msgServer.getPublicConfig(baseUrl),
 			commandCenter: app.commandCenter.getPublicConfig(baseUrl),
 			savvy: this.core.savvy.getPublicConfig(baseUrl)
 		},
 		developmentMode: this.isDevelopmentMode()
 	};
-
-	return config;
 };
 
 

--- a/lib/modules/auth/index.js
+++ b/lib/modules/auth/index.js
@@ -62,7 +62,7 @@ class UserAlreadyExistsError extends Error {
 /**
  * Returns the session module (overridden during unit tests)
  *
- * @returns {object}
+ * @returns {Object}
  */
 /* istanbul ignore next */
 exports.getSessionModule = memoize(function () {
@@ -72,7 +72,7 @@ exports.getSessionModule = memoize(function () {
 /**
  * Returns the hash configuration (overridden during unit tests)
  *
- * @returns {object}
+ * @returns {Object}
  */
 /* istanbul ignore next */
 exports.getHashConfiguration = memoize(function () {
@@ -231,7 +231,7 @@ exports.login = function (state, username, password, cb) {
  * @param {Object} options
  * @param {string|number} [options.userId]   Optional user ID. Default: a new UUID
  * @param {string[]} [options.acl]           Optional ACL array. Default: empty array
- * @returns {object}                         The created session
+ * @returns {Object}                         The created session
  */
 exports.loginAnonymous = function (state, options) {
 	const userId = (options && options.userId) || uuid();

--- a/lib/tasks/serve.js
+++ b/lib/tasks/serve.js
@@ -54,7 +54,13 @@ exports.setup = function (mage, options, cb) {
 			return callback();
 		}
 
-		mage.core.app.createApps(callback);
+		try {
+			mage.core.app.createApps();
+		} catch (error) {
+			return callback(error);
+		}
+
+		return callback();
 	}
 
 	// Set up heapdump on SIGUSR2

--- a/test/apps/index.js
+++ b/test/apps/index.js
@@ -1,0 +1,192 @@
+'use strict';
+
+const assert = require('assert');
+
+describe('apps', function () {
+	const libApp = require('lib/app');
+
+	// allow lib/app configuration override
+
+	let currentAppsConfig;
+	let currentCommandCenterSetup;
+
+	const oldFns = {
+		getAppsConfig: libApp.getAppsConfig,
+		getLogger: libApp.getLogger,
+		createCommandCenter: libApp.createCommandCenter
+	};
+
+	const testFns = {
+		getAppsConfig: function () {
+			return currentAppsConfig;
+		},
+		getLogger: function () {
+			return {
+				debug: function () {}
+			};
+		},
+		createCommandCenter: function (app) {
+			return {
+				setup: function () {
+					currentCommandCenterSetup(app);
+				}
+			};
+		}
+	};
+
+	beforeEach(function () {
+		libApp.getAppsConfig = testFns.getAppsConfig;
+		libApp.getLogger = testFns.getLogger;
+		libApp.createCommandCenter = testFns.createCommandCenter;
+	});
+
+	afterEach(function () {
+		libApp.getAppsConfig = oldFns.getAppsConfig;
+		libApp.getLogger = oldFns.getLogger;
+		libApp.createCommandCenter = oldFns.createCommandCenter;
+
+		libApp.removeAllApps();
+	});
+
+	it('creates apps', function () {
+		currentAppsConfig = {
+			app1: {},
+			app2: {}
+		};
+
+		const setupComplete = {
+			app1: null,
+			app2: null
+		};
+
+		currentCommandCenterSetup = function (app) {
+			setupComplete[app.name] = app;
+		};
+
+		libApp.createApps();
+
+		assert(setupComplete.app1);
+		assert(setupComplete.app2);
+		assert.strictEqual(Object.keys(setupComplete).length, 2);
+
+		assert.strictEqual(libApp.get('app1'), setupComplete.app1);
+		assert.strictEqual(libApp.get('app2'), setupComplete.app2);
+	});
+
+	it('skips disabled and unconfigured apps', function () {
+		currentAppsConfig = {
+			app3: {},
+			app4: { disabled: true },
+			app5: null
+		};
+
+		const setupComplete = {
+			app3: null,
+			app4: null,
+			app5: null
+		};
+
+		currentCommandCenterSetup = function (app) {
+			setupComplete[app.name] = app;
+		};
+
+		libApp.createApps();
+
+		assert(setupComplete.app3);
+		assert.strictEqual(setupComplete.app4, null);
+		assert.strictEqual(setupComplete.app5, null);
+		assert.strictEqual(Object.keys(setupComplete).length, 3);
+
+		assert.strictEqual(libApp.get('app3'), setupComplete.app3);
+		assert.strictEqual(libApp.get('app4'), undefined);
+		assert.strictEqual(libApp.get('app5'), undefined);
+	});
+
+	it('getters and deletion', function () {
+		currentAppsConfig = {
+			app7: {},
+			app8: {}
+		};
+
+		currentCommandCenterSetup = function (/* app */) {};
+
+		libApp.createApps();
+
+		const app7 = libApp.get('app7');
+		const app8 = libApp.get('app8');
+
+		assert(app7);
+		assert(app8);
+
+		assert.strictEqual(libApp.getAppMap().app7, app7);
+		assert.strictEqual(libApp.getAppMap().app8, app8);
+
+		let apps = libApp.getAppList();
+		assert.equal(apps.length, 2);
+
+		assert(apps[0] === app7 || apps[0] === app8);
+		assert(apps[1] === app7 || apps[1] === app8);
+		assert(apps[0] !== apps[1]);
+
+		libApp.removeApp('app7');
+
+		// app7 should now be gone, only app8 remains
+
+		assert.strictEqual(libApp.getAppMap().app7, undefined);
+		assert.strictEqual(libApp.getAppMap().app8, app8);
+
+		apps = libApp.getAppList();
+		assert.equal(apps.length, 1);
+
+		assert(apps[0] === app8);
+
+		libApp.removeAllApps();
+
+		// app8 should now be gone too, no apps remain
+
+		assert.strictEqual(libApp.getAppMap().app8, undefined);
+
+		apps = libApp.getAppList();
+		assert.equal(apps.length, 0);
+
+		assert.throws(() => {
+			libApp.removeApp('non-existing-app');
+		});
+	});
+
+	it('knows app readiness', function () {
+		currentAppsConfig = {
+			app9: {},
+			app10: { disabled: true }
+		};
+
+		let created = 0;
+
+		currentCommandCenterSetup = function (/* app */) {
+			created += 1;
+		};
+
+		// call createApps() multiple times, should not crash or create apps more than once
+		libApp.createApps();
+		libApp.createApps();
+		libApp.createApps();
+		assert.equal(created, 1);
+		assert.equal(libApp.isAppCreated('app9'), true);
+		assert.equal(libApp.isAppCreated('app10'), false);
+
+		libApp.createApp('app10');
+		assert.equal(created, 2);
+
+		assert.throws(() => {
+			libApp.createApp('non-existing-app');
+		});
+
+		assert.throws(() => {
+			libApp.isAppCreated('non-existing-app');
+		});
+
+		assert.throws(() => {
+			libApp.createApp('app9'); // already created
+		});
+	});
+});

--- a/test/commandCenter.js
+++ b/test/commandCenter.js
@@ -1,91 +1,155 @@
-var assert = require('assert');
-var CommandCenter = require('lib/commandCenter').CommandCenter;
-var logging = require('lib/loggingService');
+'use strict';
+
+const assert = require('assert');
+const logging = require('lib/loggingService');
+const libCC = require('lib/commandCenter');
+const CommandCenter = libCC.CommandCenter;
 
 describe('commandCenter', function () {
 	describe('CommandCenter', function () {
-		var commandCenter;
+		let cc;
 
 		before(function () {
 			// Hide "User command response cache disabled" log
 			logging.filterContexts('responseCache');
-			commandCenter = new CommandCenter({
+			cc = new CommandCenter({
 				name: 'test'
 			});
 			logging.filterContexts();
 		});
 
-		describe('buildParamList()', function () {
-			var cmdInfoModParams = ['a', 'b', 'c'];
+		describe('registerMessageHook()', function () {
+			it('Tests input types', function () {
+				const badHook = function () {
+				};
 
-			it('should build the param list from an array of the same size', function (done) {
-				var cmdParams = ['1', '2', '3'];
-				var paramList = commandCenter.buildParamList(cmdInfoModParams, cmdParams);
+				const goodHook = function (state, data, batch, cb) {
+					cb();
+				};
+
+				assert.throws(() => { libCC.registerMessageHook(123, false, goodHook); });
+				assert.throws(() => { libCC.registerMessageHook('myhook', 123, goodHook); });
+				assert.throws(() => { libCC.registerMessageHook('myhook', false, 123); });
+				assert.throws(() => { libCC.registerMessageHook('myhook', false, badHook); });
+				assert.doesNotThrow(() => { libCC.registerMessageHook('myhook', false, goodHook); });
+			});
+		});
+
+		describe('setupUserCommand()', function () {
+			it('Tests input types', function () {
+				const mod = {
+					execute: function (state, cb) {
+						cb();
+					}
+				};
+
+				assert.throws(() => { cc.setupUserCommand(123, 'login', mod); });
+				assert.throws(() => { cc.setupUserCommand('user', 123, mod); });
+				assert.throws(() => { cc.setupUserCommand('user', 'login', 123); });
+				assert.throws(() => { cc.setupUserCommand('user', 'login', {}); }); // no execute
+				assert.throws(() => { cc.setupUserCommand('user', 'login', { acl: 123, execute: () => {} }); });
+				assert.throws(() => { cc.setupUserCommand('user', 'login', { execute: () => {} }); });
+				assert.throws(() => { cc.setupUserCommand('user', 'login', { execute: (state) => {} }); }); // eslint-disable-line
+			});
+
+			it('Registers a user command', function () {
+				const mod = {
+					execute: function (state, cb) {
+						cb();
+					}
+				};
+
+				cc.setupUserCommand('user', 'login', mod);
+			});
+		});
+
+		describe('getPublicConfig()', function () {
+			it('Communicates a user command', function () {
+				const mod = {
+					execute: function (state, foo, cb) {
+						cb();
+					}
+				};
+
+				cc.setupUserCommand('user', 'login', mod);
+				const config = cc.getPublicConfig('');
+
+				assert.equal(config.url, '/test');
+				assert.deepEqual(config.commands, {
+					user: [
+						{ name: 'login', params: ['foo'] }
+					]
+				});
+			});
+		});
+
+		describe('buildParamList()', function () {
+			const cmdInfoModParams = ['a', 'b', 'c'];
+
+			it('Tests input types', function () {
+				assert.throws(() => { cc.buildParamList(123, []); });
+				assert.throws(() => { cc.buildParamList([], 123); });
+				assert.doesNotThrow(() => { cc.buildParamList([], []); });
+				assert.doesNotThrow(() => { cc.buildParamList([], {}); });
+			});
+
+			it('should build the param list from an array of the same size', function () {
+				const cmdParams = ['1', '2', '3'];
+				const paramList = cc.buildParamList(cmdInfoModParams, cmdParams);
 				assert.strictEqual(Array.isArray(paramList), true);
 				assert.strictEqual(paramList.length, 3);
 				assert.deepEqual(paramList, cmdParams);
-				done();
 			});
 
-			it('should build the param list from a smaller array', function (done) {
-				var cmdParams = ['1', '2'];
-				var paramList = commandCenter.buildParamList(cmdInfoModParams, cmdParams);
+			it('should build the param list from a smaller array', function () {
+				const cmdParams = ['1', '2'];
+				const paramList = cc.buildParamList(cmdInfoModParams, cmdParams);
 				assert.strictEqual(Array.isArray(paramList), true);
 				assert.strictEqual(paramList.length, 3);
 				assert.deepEqual(paramList, ['1', '2', undefined]);
-				done();
 			});
 
-			it('should throw an exception if the array is too big', function (done) {
-				var cmdParams = ['1', '2', '4', '5'];
-				try {
-					commandCenter.buildParamList(cmdInfoModParams, cmdParams);
-				} catch (err) {
-					assert.strictEqual(err.message, 'Too many parameters provided.');
-					return done();
-				}
-				done('No error caught.');
+			it('should throw an exception if the array is too big', function () {
+				const cmdParams = ['1', '2', '4', '5'];
+				assert.throws(() => { cc.buildParamList(cmdInfoModParams, cmdParams); });
 			});
 
-			it('should build the param list from an object', function (done) {
-				var cmdParams = {
+			it('should build the param list from an object', function () {
+				const cmdParams = {
 					a: '1',
 					b: '2',
 					c: '3'
 				};
-				var paramList = commandCenter.buildParamList(cmdInfoModParams, cmdParams);
+				const paramList = cc.buildParamList(cmdInfoModParams, cmdParams);
 				assert.strictEqual(Array.isArray(paramList), true);
 				assert.strictEqual(paramList.length, 3);
 				assert.deepEqual(paramList, ['1', '2', '3']);
-				done();
 			});
 
-			it('should build the param list from an object with missing params', function (done) {
-				var cmdParams = {
+			it('should build the param list from an object with missing params', function () {
+				const cmdParams = {
 					a: '1',
 					c: '2',
 					e: '3'
 				};
-				var paramList = commandCenter.buildParamList(cmdInfoModParams, cmdParams);
+				const paramList = cc.buildParamList(cmdInfoModParams, cmdParams);
 				assert.strictEqual(Array.isArray(paramList), true);
 				assert.strictEqual(paramList.length, 3);
 				assert.deepEqual(paramList, ['1', undefined, '2']);
-				done();
 			});
 
-			it('should build the param list from an object with too many params', function (done) {
-				var cmdParams = {
+			it('should build the param list from an object with too many params', function () {
+				const cmdParams = {
 					a: '1',
 					c: '2',
 					e: '3',
 					b: '4',
 					g: '5'
 				};
-				var paramList = commandCenter.buildParamList(cmdInfoModParams, cmdParams);
+				const paramList = cc.buildParamList(cmdInfoModParams, cmdParams);
 				assert.strictEqual(Array.isArray(paramList), true);
 				assert.strictEqual(paramList.length, 3);
 				assert.deepEqual(paramList, ['1', '4', '2']);
-				done();
 			});
 		});
 	});

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,7 @@ require('./state');
 require('./savvy');
 require('./archivist');
 require('./commandCenter');
+require('./apps');
 require('./serviceDiscovery');
 require('./processMessenger');
 require('./msgServer');

--- a/test/modules/auth/index.js
+++ b/test/modules/auth/index.js
@@ -76,7 +76,7 @@ describe('auth', function () {
 		});
 	});
 
-	after(function () {
+	afterEach(function () {
 		auth.getSessionModule = oldFns.getSessionModule;
 		auth.getHashConfiguration = oldFns.getHashConfiguration;
 		auth.getArchivistTopic = oldFns.getArchivistTopic;


### PR DESCRIPTION
These used to be asynchronous, but since it's during the startup phase only, synchronous doesn't hurt. More importantly, this makes `webpack.config.js` a lot easier to implement, since you don't need to mess about with promises and asynchronous flow during configuration.

After making those changes, I've also made `createApps` unnecessary when calling `mage.getClientConfig(appName)`. Now, that method will automatically create the app if it wasn't created yet. On top of that, `createApps()` will ignore any apps already created, so it's perfectly safe to create one app first, and all other apps later for example. This change further simplified the Webpack config.

**BC breakage**: Nobody was using this, but regardless, this PR removes configuration entry `apps: appName: appConfig`.

**BC breakage**: `mage.core.app.createApps(cb)` no longer takes a callback, as it's now synchronous. Normally this method is called by mage itself, but build configurations (ie: Webpack) have called it to do a partial mage setup. That is however no longer needed.

**BC breakage**: This removes the `baseUrl` argument from `mage.getClientConfig(appName, baseUrl)` and pulls the information out of httpServer (which gets it from configuration). That should make its usage more intuitive. Up until now, all applications that I'm aware of passed empty string anyway, so this change should not have a negative impact.

**BC breakage**: Configuration `server.clientHost.expose` no longer supports object notation, and now only allows strings. As far as I'm aware, no existing projects use this notation anyway, but this really keeps things simpler. Non-strings will throw. Tests have been updated accordingly, and coverage is good.

Testing: Changes are all fully covered. I've also successfully tested this on a project.

Typical impact on `webpack.config.js`:

> Before: webpack.config.js

```js
'use strict';

const webpack = require('webpack');

const baseUrl = '';

let config;
let devMode;

function setupApp() {
	return new Promise((resolve, reject) => {
		const mage = require('./lib');

		mage.core.app.createApps((error) => {
			if (error) {
				return reject(error);
			}

			config = mage.getClientConfig('api', baseUrl);
			devMode = mage.isDevelopmentMode();

			return resolve();
		});
	});
}


module.exports = setupApp().then(() => {
	return {
                // ... config properties
		plugins: [
			new webpack.DefinePlugin({
				MAGE_CONFIG: JSON.stringify(config),
				DEBUG: JSON.stringify(devMode)
			})
		]
	};
});
```

> After: webpack.config.js

```js
'use strict';

const webpack = require('webpack');
const mage = require('./lib');

module.exports = {
        // ... config properties
	plugins: [
		new webpack.DefinePlugin({
			MAGE_CONFIG: JSON.stringify(mage.getClientConfig('api')),
			DEBUG: JSON.stringify(mage.isDevelopmentMode())
		})
	]
};
```