### PR TITLE
Config node 4 enhancements

### DIFF
--- a/lib/config/Matryoshka/index.js
+++ b/lib/config/Matryoshka/index.js
@@ -115,12 +115,8 @@ class Matryoshka {
 			return child.tunnel(path.slice(1));
 		}
 
-		// Tunnel into the child with the remaining path.
-		if (child && child instanceof Matryoshka) {
-			child.tunnel(path.slice(1));
-		}
-
 		// If the child is not a Matryoshka, then we can't do anything with it.
+		return;
 	}
 
 	/**
@@ -178,8 +174,11 @@ class Matryoshka {
 			sources = sources.concat(obj.getAllSourcesWithPath([key]));
 		}
 
+		// Returns an array with unique elements from a given array.
+		const dedupe = array => Array.from(new Set(array));
+
 		// remove duplicates
-		return Array.from(new Set(sources));
+		return dedupe(sources);
 	}
 
 	/**
@@ -216,8 +215,8 @@ class Matryoshka {
 	}
 
 	/**
-	 * An extended merge. This can take any number of arguments, in order of increasing importance. All
-	 * arguments must be matryoshka.
+	 * An extended merge. This can take any number of arguments, in order of increasing importance.
+	 * All arguments must be matryoshka.
 	 *
 	 * @return {Matryoshka} The resulting matryoshka.
 	 */
@@ -264,30 +263,6 @@ function getRawRecursive(matryoshka) {
 }
 
 /**
- * Merge two matryoshka instances to produce a third. This does not affect the parents in any way.
- *
- * @param  {Matryoshka} a A matryoshka of lower importance.
- * @param  {Matryoshka} b A matryoshka of higher importance.
- * @return {Matryoshka}   The resultant matryoshka.
- */
-
-function mergeObjects(a, b) {
-	const aKeys = Object.keys(a.value);
-	const bKeys = Object.keys(b.value);
-	const joinKeys = Array.from(new Set(aKeys.concat(bKeys)));
-	const returnObj = {};
-
-	// Compare each key-by-key.
-	for (const key of joinKeys) {
-		returnObj[key] = merge(a.value[key], b.value[key]);
-	}
-
-	// Make a new matryoshka with the results.
-	return new Matryoshka(returnObj, a.source, true);
-}
-
-
-/**
  * Merges a and b together into a new Matryoshka. Does not affect the state of a or b, and b
  * overrides a. At least one is guaranteed to be a Matryoshka.
  *
@@ -322,7 +297,21 @@ function merge(a, b) {
 	}
 
 	// If we reached here, then both a and b contain objects to be compared key-by-key.
-	return mergeObjects(a, b);
+
+	// First assemble a list of keys in one or both objects.
+	const aKeys = Object.keys(a.value);
+	const bKeys = Object.keys(b.value);
+	const uniqueKeys = new Set(aKeys.concat(bKeys));
+
+	const merged = {};
+
+	// Merge key-by-key.
+	for (const key of uniqueKeys) {
+		merged[key] = merge(a.value[key], b.value[key]);
+	}
+
+	// Wrap the merged object in a Matryoshka.
+	return new Matryoshka(merged, a.source, true);
 }
 
 // The Matryoshka constructor is exposed as the module.

--- a/lib/config/Matryoshka/index.js
+++ b/lib/config/Matryoshka/index.js
@@ -140,12 +140,6 @@ Matryoshka.prototype.tunnel = function (path) {
  */
 
 function getRaw(matryoshka) {
-	var isMatryoshka = matryoshka instanceof Matryoshka;
-
-	if (!isMatryoshka) {
-		return matryoshka;
-	}
-
 	if (matryoshka.type === 'object') {
 		var returnObj = {};
 		var keys = Object.keys(matryoshka.value);
@@ -273,10 +267,6 @@ Matryoshka.prototype.copy = function () {
  */
 
 function mergeObjects(a, b) {
-	if (a.type !== 'object' || b.type !== 'object') {
-		throw new TypeError('Arguments must be (non-null, non-array) object containing Matryoshka.');
-	}
-
 	var joinKeys = Object.keys(a.value);
 	var bKeys = Object.keys(b.value);
 
@@ -305,7 +295,7 @@ function mergeObjects(a, b) {
 
 /**
  * Merges a and b together into a new Matryoshka. Does not affect the state of a or b, and b
- * overrides a.
+ * overrides a. At least one is guaranteed to be a Matryoshka.
  *
  * @param  {Matryoshka} a Matryoshka of lesser importance.
  * @param  {Matryoshka} b Matryoshka of greater importance.
@@ -313,20 +303,13 @@ function mergeObjects(a, b) {
  */
 
 function merge(a, b) {
-	var aIsMatryoshka = a instanceof Matryoshka;
-	var bIsMatryoshka = b instanceof Matryoshka;
-
-	if (!aIsMatryoshka && !bIsMatryoshka) {
-		throw new TypeError('Arguments must be matryoshka instances.');
-	}
-
 	// If a is not a matryoshka, then return a copy of b (override).
-	if (!aIsMatryoshka) {
+	if (!(a instanceof Matryoshka)) {
 		return b.copy();
 	}
 
 	// If b is not a matryoshka, then just keep a.
-	if (!bIsMatryoshka) {
+	if (!(b instanceof Matryoshka)) {
 		return a.copy();
 	}
 
@@ -350,7 +333,8 @@ function merge(a, b) {
 
 
 /**
- * An extended merge. This can take any number of arguments, in order of increasing importance.
+ * An extended merge. This can take any number of arguments, in order of increasing importance. All
+ * arguments must be matryoshka.
  *
  * @return {Matryoshka} The resulting matryoshka.
  */
@@ -360,10 +344,16 @@ Matryoshka.merge = function () {
 		throw new Error('Merge takes at least one Matryoshka instance.');
 	}
 
+	for (var i = 0; i < arguments.length; i++) {
+		if (!(arguments[i] instanceof Matryoshka)) {
+			throw new TypeError('Arguments must be matryoshka instances.');
+		}
+	}
+
 	var merged = arguments[0].copy();
 
-	for (var i = 1; i < arguments.length; i++) {
-		merged = merge(merged, arguments[i]);
+	for (var j = 1; j < arguments.length; j++) {
+		merged = merge(merged, arguments[j]);
 	}
 
 	return merged;

--- a/lib/config/Matryoshka/index.js
+++ b/lib/config/Matryoshka/index.js
@@ -1,11 +1,10 @@
-var deepCopy = require('wizcorp-deep-copy.js');
+'use strict';
+
+const deepCopy = require('wizcorp-deep-copy.js');
 
 /**
  * @module Matryoshka
  */
-
-/* jshint latedef: false */
-
 
 /**
  * Make a matryoshka container for an some data. Objects are nested.
@@ -16,120 +15,231 @@ var deepCopy = require('wizcorp-deep-copy.js');
  * @alias module:Matryoshka
  */
 
-function Matryoshka(value, source, shallow) {
-	if (!(this instanceof Matryoshka)) {
-		return new Matryoshka(value, source, shallow);
-	}
+class Matryoshka {
+	constructor(value, source, shallow) {
+		this.source = source;
 
-	this.source = source;
+		// Primitive values and arrays are treated as scalars.
+		if (!value || typeof value !== 'object' || Array.isArray(value)) {
+			this.value = value;
+			this.type = 'scalar';
 
-	// Like Arrays, elements in objects are placed in containers.
-	if (value && typeof value === 'object' && !Array.isArray(value)) {
+			return;
+		}
+
+		// Elements in objects are placed in containers.
 		this.type = 'object';
 
 		if (shallow) {
 			this.value = value;
-			return this;
+
+			return;
 		}
 
 		this.value = {};
 
-		var keys = Object.keys(value);
+		for (const key of Object.keys(value)) {
+			this.value[key] = new Matryoshka(value[key], source);
+		}
+	}
 
-		for (var j = 0; j < keys.length; j++) {
-			this.value[keys[j]] = new Matryoshka(value[keys[j]], source);
+	/**
+	 * Simple getter. Nothing to see here.
+	 *
+	 * @return {*} Contained value.
+	 */
+
+	getValue() {
+		return this.value;
+	}
+
+	/**
+	 * Get the type of the matryoshka. The two types are:
+	 *
+	 *  - object
+	 *  - scalar
+	 *
+	 * These reflect the structure of the data. For example, null is not an object in this system, it is
+	 * a scalar. The types are exclusive, so arrays are not considered to be objects. This is to aid in
+	 * determining how copies are performed etc.
+	 *
+	 * @return {String} Matryoshka type.
+	 */
+
+	getType() {
+		return this.type;
+	}
+
+	/**
+	 * Return the source of origin for contained data.
+	 *
+	 * @return {string} The source of a value (generally a file)
+	 */
+
+	getSource() {
+		return this.source;
+	}
+
+	/**
+	 * Use a path to tunnel down through a Matryoshka instance. It returns the Matryoshka from the point
+	 * indexed by the path.
+	 *
+	 * @param  {string[]}             path   A tunnel path.
+	 * @return {Matryoshka|undefined}        The Matryoshka from the point addressed by the path.
+	 */
+
+	tunnel(path) {
+		if (!Array.isArray(path)) {
+			throw new TypeError('Addressing must be done with an array of strings');
 		}
 
-		return this;
+		// If the path is empty, just return this Matryoshka. This can happen if the original path was empty.
+		if (path.length === 0) {
+			return this;
+		}
+
+		const pathSegment = path[0];
+
+		if (typeof pathSegment !== 'string') {
+			throw new TypeError('Path segment was not a string: ' + pathSegment);
+		}
+
+		if (!this.value) {
+			return;
+		}
+
+		const child = this.value[pathSegment];
+
+		if (child && child instanceof Matryoshka) {
+			// Tunnel into the child with the remaining path.
+			return child.tunnel(path.slice(1));
+		}
+
+		// Tunnel into the child with the remaining path.
+		if (child && child instanceof Matryoshka) {
+			child.tunnel(path.slice(1));
+		}
+
+		// If the child is not a Matryoshka, then we can't do anything with it.
 	}
 
-	// The remaining case includes the set of all scalar types, including arrays.
-	this.value = value;
-	this.type = 'scalar';
+	/**
+	 * Get the raw form of configuration from a particular key down.
+	 *
+	 * @param  {string[]} path       A list of keys to dig into the abstract raw object.
+	 * @param  {*}        defaultVal In the event that there is no data at the path given, return this.
+	 * @return {*}                   The addressed raw value or defaultVal.
+	 */
 
-	return this;
+	get(path, defaultVal) {
+		const obj = this.tunnel(path);
+
+		return obj ? obj.getRaw() : defaultVal;
+	}
+
+	/**
+	 * Get the source of the configuration at some depth.
+	 *
+	 * @param  {string[]} path A path to address data within a Matryoshka instance.
+	 * @return {*}             The source information for the addressed key.
+	 */
+
+	getSourceWithPath(path) {
+		const obj = this.tunnel(path);
+
+		if (obj) {
+			return obj.source;
+		}
+	}
+
+	/**
+	 * Get a unique list of all sources of the configuration at a particular depth for itself and all children.
+	 *
+	 * @param  {string[]} path A path to address data within a Matryoshka instance.
+	 * @return {string[]}      The sources information for the addressed key and its children.
+	 */
+
+	getAllSourcesWithPath(path) {
+		const obj = this.tunnel(path);
+
+		let sources = [];
+
+		if (!obj) {
+			return sources;
+		}
+
+		sources.push(obj.source);
+
+		if (obj.type !== 'object') {
+			return sources;
+		}
+
+		for (const key of Object.keys(obj.value)) {
+			sources = sources.concat(obj.getAllSourcesWithPath([key]));
+		}
+
+		// remove duplicates
+		return Array.from(new Set(sources));
+	}
+
+	/**
+	 * Get the raw representation of the data in a matryoshka. As matryoshkas nest, this essentially
+	 * dematryoshikisizes.
+	 *
+	 * @return {*} Get the raw value of something contained in a matryoshka. This is recursive.
+	 */
+
+	getRaw() {
+		return getRawRecursive(this);
+	}
+
+	/**
+	 * A copy constructor in C++ parlance. Makes a complete copy. No references in common with original.
+	 *
+	 * @return {Matryoshka} A fresh, deep copy of the original matryoshka.
+	 */
+
+	copy() {
+		// Non-objects are subjected to a deep copy (arrays are treated as values).
+		if (this.type !== 'object') {
+			return new Matryoshka(deepCopy(this.value), this.source, true);
+		}
+
+		// Objects need to be copied key-by-key.
+		const toReturn = {};
+
+		for (const key of Object.keys(this.value)) {
+			toReturn[key] = this.value[key].copy();
+		}
+
+		return new Matryoshka(toReturn, this.source, true);
+	}
+
+	/**
+	 * An extended merge. This can take any number of arguments, in order of increasing importance. All
+	 * arguments must be matryoshka.
+	 *
+	 * @return {Matryoshka} The resulting matryoshka.
+	 */
+
+	static merge() {
+		if (!arguments.length) {
+			throw new Error('Merge takes at least one Matryoshka instance.');
+		}
+
+		let merged;
+
+		for (const m of arguments) {
+			if (!(m instanceof Matryoshka)) {
+				throw new TypeError('Arguments must be matryoshka instances.');
+			}
+
+			merged = merge(merged, m);
+		}
+
+		return merged;
+	}
 }
-
-
-/**
- * Simple getter. Nothing to see here.
- *
- * @return {*} Contained value.
- */
-
-Matryoshka.prototype.getValue = function () {
-	return this.value;
-};
-
-
-/**
- * Get the type of the matryoshka. The two types are:
- *
- *  - object
- *  - scalar
- *
- * These reflect the structure of the data. For example, null is not an object in this system, it is
- * a scalar. The types are exclusive, so arrays are not considered to be objects. This is to aid in
- * determining how copies are performed etc.
- *
- * @return {String} Matryoshka type.
- */
-
-Matryoshka.prototype.getType = function () {
-	return this.type;
-};
-
-
-/**
- * Return the source of origin for contained data.
- *
- * @return {string} The source of a value (generally a file)
- */
-
-Matryoshka.prototype.getSource = function () {
-	return this.source;
-};
-
-
-/**
- * Use a path to tunnel down through a Matryoshka instance. It returns the Matryoshka from the point
- * indexed by the path.
- *
- * @param  {string[]}             path   A tunnel path.
- * @return {Matryoshka|undefined}        The Matryoshka from the point addressed by the path.
- */
-
-Matryoshka.prototype.tunnel = function (path) {
-	if (!Array.isArray(path)) {
-		throw new TypeError('Addressing must be done with an array of strings');
-	}
-
-	// If the path is empty, just return this Matryoshka. This can happen if the original path was empty.
-	if (path.length === 0) {
-		return this;
-	}
-
-	var pathSegment = path[0];
-
-	if (typeof pathSegment !== 'string') {
-		throw new TypeError('Path segment was not a string: ' + pathSegment);
-	}
-
-	if (!this.value) {
-		return;
-	}
-
-	var child = this.value[pathSegment];
-
-	// If the child is not a Matryoshka, then we can't do anything with it.
-	if (!child || !(child instanceof Matryoshka)) {
-		return;
-	}
-
-	// Tunnel into the child with the remaining path.
-	return child.tunnel(path.slice(1));
-};
-
 
 /**
  * Recursively unpeel a matryoshka to recover the raw data.
@@ -139,124 +249,19 @@ Matryoshka.prototype.tunnel = function (path) {
  * @private
  */
 
-function getRaw(matryoshka) {
-	if (matryoshka.type === 'object') {
-		var returnObj = {};
-		var keys = Object.keys(matryoshka.value);
-
-		for (var i = 0; i < keys.length; i++) {
-			returnObj[keys[i]] = getRaw(matryoshka.value[keys[i]]);
-		}
-
-		return returnObj;
+function getRawRecursive(matryoshka) {
+	if (matryoshka.type !== 'object') {
+		return matryoshka.value;
 	}
 
-	return matryoshka.value;
+	const returnObj = {};
+
+	for (const key of Object.keys(matryoshka.value)) {
+		returnObj[key] = getRawRecursive(matryoshka.value[key]);
+	}
+
+	return returnObj;
 }
-
-
-/**
- * Get the raw form of configuration from a particular key down.
- *
- * @param  {string[]} path       A list of keys to dig into the abstract raw object.
- * @param  {*}        defaultVal In the event that there is no data at the path given, return this.
- * @return {*}                   The addressed raw value or defaultVal.
- */
-
-Matryoshka.prototype.get = function (path, defaultVal) {
-	var obj = this.tunnel(path);
-
-	if (obj) {
-		return obj.getRaw();
-	}
-
-	return defaultVal;
-};
-
-
-/**
- * Get the source of the configuration at some depth.
- *
- * @param  {string[]} path A path to address data within a Matryoshka instance.
- * @return {*}             The source information for the addressed key.
- */
-
-Matryoshka.prototype.getSourceWithPath = function (path) {
-	var obj = this.tunnel(path);
-
-	if (obj) {
-		return obj.source;
-	}
-};
-
-
-/**
- * Get a unique list of all sources of the configuration at a particular depth for itself and all children.
- *
- * @param  {string[]} path A path to address data within a Matryoshka instance.
- * @return {string[]}      The sources information for the addressed key and its children.
- */
-
-Matryoshka.prototype.getAllSourcesWithPath = function (path) {
-	var obj = this.tunnel(path);
-	var sources = [];
-
-	if (obj) {
-		sources.push(obj.source);
-
-		if (obj.type === 'object') {
-			var keys = Object.keys(obj.value);
-			for (var i = 0; i < keys.length; i++) {
-				sources = sources.concat(obj.getAllSourcesWithPath([keys[i]]));
-			}
-		}
-	}
-
-	// remove duplicates
-
-	return sources.filter(function (source, index) {
-		return sources.indexOf(source) === index;
-	});
-};
-
-
-/**
- * Get the raw representation of the data in a matryoshka. As matryoshkas nest, this essentially
- * dematryoshikisizes.
- *
- * @return {*} Get the raw value of something contained in a matryoshka. This is recursive.
- */
-
-Matryoshka.prototype.getRaw = function () {
-	return getRaw(this);
-};
-
-
-/**
- * A copy constructor in C++ parlance. Makes a complete copy. No references in common with original.
- *
- * @return {Matryoshka} A fresh, deep copy of the original matryoshka.
- */
-
-Matryoshka.prototype.copy = function () {
-	// Non-objects are subjected to a deep copy (arrays are treated as values).
-	if (this.type !== 'object') {
-		return new Matryoshka(deepCopy(this.value), this.source, true);
-	}
-
-	// Objects need to be copied key-by-key.
-	var keys = Object.keys(this.value);
-	var toReturn = {};
-
-	for (var i = 0; i < keys.length; i++) {
-		var key = keys[i];
-
-		toReturn[key] = this.value[key].copy();
-	}
-
-	return new Matryoshka(toReturn, this.source, true);
-};
-
 
 /**
  * Merge two matryoshka instances to produce a third. This does not affect the parents in any way.
@@ -267,24 +272,13 @@ Matryoshka.prototype.copy = function () {
  */
 
 function mergeObjects(a, b) {
-	var joinKeys = Object.keys(a.value);
-	var bKeys = Object.keys(b.value);
-
-	// Add keys from b.value that were not present in a.value;
-	for (var i = 0; i < bKeys.length; i++) {
-		var bKey = bKeys[i];
-
-		if (joinKeys.indexOf(bKey) === -1) {
-			joinKeys.push(bKey);
-		}
-	}
-
-	var returnObj = {};
+	const aKeys = Object.keys(a.value);
+	const bKeys = Object.keys(b.value);
+	const joinKeys = Array.from(new Set(aKeys.concat(bKeys)));
+	const returnObj = {};
 
 	// Compare each key-by-key.
-	for (var j = 0; j < joinKeys.length; j++) {
-		var key = joinKeys[j];
-
+	for (const key of joinKeys) {
 		returnObj[key] = merge(a.value[key], b.value[key]);
 	}
 
@@ -331,33 +325,5 @@ function merge(a, b) {
 	return mergeObjects(a, b);
 }
 
-
-/**
- * An extended merge. This can take any number of arguments, in order of increasing importance. All
- * arguments must be matryoshka.
- *
- * @return {Matryoshka} The resulting matryoshka.
- */
-
-Matryoshka.merge = function () {
-	if (arguments.length < 1) {
-		throw new Error('Merge takes at least one Matryoshka instance.');
-	}
-
-	for (var i = 0; i < arguments.length; i++) {
-		if (!(arguments[i] instanceof Matryoshka)) {
-			throw new TypeError('Arguments must be matryoshka instances.');
-		}
-	}
-
-	var merged = arguments[0].copy();
-
-	for (var j = 1; j < arguments.length; j++) {
-		merged = merge(merged, arguments[j]);
-	}
-
-	return merged;
-};
-
-// The Matryoshka constructor is exposed as the module. The shallow is bound out.
+// The Matryoshka constructor is exposed as the module.
 module.exports = Matryoshka;

--- a/test/config.js
+++ b/test/config.js
@@ -10,16 +10,9 @@ function compareArrays(a, b) {
 	}
 }
 
-describe('A matryoshka instance', function () {
+describe.only('A matryoshka instance', function () {
 	it('should be constructable.', function (done) {
 		var matryoshka = new Matryoshka();
-
-		assert(matryoshka instanceof Matryoshka);
-		done();
-	});
-
-	it('should handle calls without new.', function (done) {
-		var matryoshka = Matryoshka(); // eslint-disable-line new-cap
 
 		assert(matryoshka instanceof Matryoshka);
 		done();


### PR DESCRIPTION
Some speculative changes as discussed in #14. This PR supersedes #14 if it is deemed acceptable.

Changes to Matryoshka were done against the old tests. The sole breakage is that Matryoshka can no longer created without using `new`. Since this was unused behaviour I went ahead and used a `class`.

Following those changes, I trashed most of the tests and rewrote them in a more structured way. Hopefully it makes the intended behaviour clearer.