### PR TITLE
Remove legacy "access" config

### DIFF
--- a/scripts/templates/create-project/config/default.yaml
+++ b/scripts/templates/create-project/config/default.yaml
@@ -16,9 +16,6 @@ apps:
         # Number of seconds to keep user command responses cached (to mitigate weak client connections)
         responseCache: 30
 
-        # The maximum access level for this app (user commands with a higher level are not exposed)
-        access: user
-
 # Define how we want to log debug information, notices, warnings, errors, etc
 
 logging:


### PR DESCRIPTION
This has not been used for ages, but was still left in our template.