### PR TITLE
Support proper versioning through NPM

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,5 @@ heading = mage
 progress = false
 loglevel = http
 save-prefix = ""
+message = "Release %s"
+tag-version-prefix = ""

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -1,0 +1,24 @@
+# Release Guide
+
+## Versioning scheme
+
+We apply a semver-ish versioning scheme, using the following logic:
+
+- `major`: major version number is always "1"
+- `minor`: release includes backwards incompatible changes
+- `patch`: bugfix release or backwards compatible changes/features
+
+## How to release
+
+1. Ensure your shell is in the `master` branch
+2. Ensure you are up-to-date: `git pull upstream master` (where "upstream" references https://github.com/mage/mage)
+3. Determine whether this release is a major, minor or patch release
+4. Run: `npm version major`, `npm version minor` or `npm version patch`. This will have:
+    1. Updated the version in package.json
+    2. Regenerated documentation
+    3. Committed (git)
+    4. Tagged (git)
+5. Run: `git push upstream master --tags` (where "upstream" references https://github.com/mage/mage)
+6. Write up the release notes at the new tag on https://github.com/mage/mage/releases/new
+7. Run: `npm publish`
+8. Spread the news on the relevant communication channels

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:unit-rebuild": "npm rebuild && npm run test:unit",
     "test": "run-s test:lint test:unit test:security",
     "postinstall": "link-require ./lib:lib && node ./scripts/install.js",
+    "preversion": "npm run docs:build && git add ./docs",
     "report:coveralls": "istanbul cover _mocha --root lib --include-all-sources --report lcovonly --dir coveralls -- -R mocha-reporter ./test/index.js && cat ./coveralls/lcov.info | coveralls && rm -rf ./coveralls",
     "report:coverage": "istanbul cover _mocha --root lib --include-all-sources --report html --dir coverage-report -- -R mocha-reporter ./test/index.js",
     "report:complexity:create-config": "yaml2json .eslintrc.yml > .eslintrc",


### PR DESCRIPTION
This allows "npm version <version/major/minor/patch>" to do its thing, while generating uptodate docs for the release commit. It also includes a release guide to document the entire release process.