### PR TITLE
state.emit/broadcast eventName can be number, type

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -1431,22 +1431,22 @@ declare namespace mage {
              * is not currently connected.
              *
              * @param {(string | string[])} actorId
-             * @param {string} eventName
+             * @param {string | number} eventName
              * @param {*} data
              *
              * @memberOf State
              */
-            emit(actorId: string | string[], eventName: string, data: any): void;
+            emit<T>(actorId: string | string[], eventName: string | number, data: T): void;
 
             /**
              * Broadcast an event to all connected users
              *
-             * @param {string} eventName
+             * @param {string | number} eventName
              * @param {*} data
              *
              * @memberOf State
              */
-            broadcast(eventName: string, data: any): void;
+            broadcast<T>(eventName: string | number, data: T): void;
 
             /**
              * Register a session on the user


### PR DESCRIPTION
This is to allow better type analysis by the parser;
it also allows for developers to explicitly type the call,
as follow:

```typescript
state.broadcast<string>('hello', 'world')
```

Also, allowing for the eventName to be a number allows
for the following code pattern:

```typescript
// lib/modules/test/index.ts
import * as mage from 'mage'

export const enum events {
  Success = 5000,
  Failure,
  Dunno
}

export function emitSuccessValue(actorId: string, state: mage.core.IState) {
  state.emit(actorId, events.Success, 1)
}
```