### PR TITLE
IUserCommand.execute type

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -1362,7 +1362,7 @@ declare namespace mage {
          */
         interface IUserCommand {
             acl?: string[];
-            execute(state: IState, ...args: any[]): any;
+            execute<T>(state: IState, ...args: any[]): Promise<T>;
         }
 
         export interface IState {


### PR DESCRIPTION
Enforce type on usercommand.execute. This will:

  1. Pick up if the `async` keyword is missing
  2. Allow for explicity typedefinition if desirable

Note that while MAGE supports callback-based user commands,
they would now become invalid for TypeScript; the reason for this
that the only valid type definition we could introduce is the following:

execute<T>(state: IState, ...args: any[]): T;

Which would:

  1. Not check that the last parameter is an empty callback function
  2. Essentially make checking for the `async` keyword impossible
  (because of the overloading)

Since we are promoting the use of `async` anyway, I figured out this
wouldn't matter; beside, if a developer really wanted to use
callback-based execute function, they could always write it like
without typing.