### PR TITLE
module index file not required

### DIFF
--- a/lib/mage/Mage.js
+++ b/lib/mage/Mage.js
@@ -410,13 +410,23 @@ Mage.prototype.useModules = function () {
 		this._modulesList.push({ name: name, path: resolved });
 		this._setupQueue.push(name);
 
+		var mod = {};
+
 		try {
-			var mod = require(resolved);
-			this[name] = this.core.modules[name] = mod;
+			mod = require(resolved);
 		} catch (error) {
-			error.module = name;
-			error.moduleFile = resolved;
-			throw error;
+			if (error.code !== 'MODULE_NOT_FOUND') {
+				error.module = name;
+				error.moduleFile = resolved;
+				throw error;
+			}
+
+			this.core.logger.warning.data({
+				moduleName: name,
+				modulePath: resolved
+			}).log('Module "' + name + '" has no implementation.');
+		} finally {
+			this[name] = this.core.modules[name] = mod;
 		}
 	}
 
@@ -450,7 +460,20 @@ Mage.prototype.getModulePath = function (name) {
 		var mod = this._modulesList[i];
 
 		if (mod.name === name) {
-			return path.dirname(require.resolve(mod.path));
+			var modPath = mod.path;
+
+			try {
+				// This is required for cases where we might be importing
+				// MAGE modules that are also Node.js modules, e.g. they
+				// have their own `package.json` file
+				modPath = path.dirname(require.resolve(mod.path));
+			} catch (error) {
+				if (error.code !== 'MODULE_NOT_FOUND') {
+					throw error;
+				}
+			}
+
+			return modPath;
 		}
 	}
 


### PR DESCRIPTION
In projects, the following structure is now OK:

```plaintext
lib/
  modules/
    moduleWithOnlyUserCommands/
      usercommands/
        a.js
        b.js
        c.js
```

Notice that there are no `index.js` in the module (in which
case, a warning log will be printed out nevertheless)

Fixes #35 