### PR TITLE
savvy socket file config: absolute paths

### DIFF
--- a/lib/savvy/config.yaml
+++ b/lib/savvy/config.yaml
@@ -1,1 +1,1 @@
-sockfile: "savvy"
+sockfile: "savvy.sock"

--- a/lib/savvy/index.js
+++ b/lib/savvy/index.js
@@ -10,14 +10,12 @@ mage.core.config.setTopLevelDefault('savvy', path.join(__dirname, 'config.yaml')
 var ROUTE_STR = '/savvy';
 var ROUTE_RE = new RegExp('^' + ROUTE_STR + '/');
 
-var SOCK_PATH;
 var SOCK_FILE = mage.core.config.get(['savvy', 'sockfile']);
-if (process.platform === 'win32') {
-	SOCK_PATH = path.join('\\\\.\\pipe', process.cwd(), SOCK_FILE);
-} else {
-	SOCK_PATH = path.join(process.cwd(), SOCK_FILE + '.sock');
-}
+var SOCK_PATH = path.resolve(SOCK_FILE);
 
+if (process.platform === 'win32') {
+	SOCK_PATH = path.join('\\\\.\\pipe', SOCK_PATH);
+}
 
 function trimRegExp(re) {
 	re = re.toString();


### PR DESCRIPTION
With this fix, it should now be possible to specify absolute
paths in your configuration.

Fixes #26