### PR TITLE
user command access: more explicit logs on acl err

### DIFF
--- a/lib/commandCenter/commandCenter.js
+++ b/lib/commandCenter/commandCenter.js
@@ -491,17 +491,28 @@ CommandCenter.prototype.executeCommand = function (cmd, session, metaData, cb) {
 
 	// check if access control list grants the proper access
 	if (!state.canAccess(cmdInfo.mod.acl)) {
-		var errorText = 'User command access level not satisfied for command "' + cmd.name +
-			'" on app "' + this.app.name + '".';
+		// Create a log entry
+		var logEntry = logger.error.data({
+			app: this.app.name,
+			module: cmdInfo.mod.name,
+			command: cmd.name,
+			acl: {
+				state: state.acl,
+				command: cmdInfo.mod.acl
+			}
+		});
 
+		// Add some log details depending on whether the command defines ACLs
 		if (cmdInfo.mod.acl) {
-			errorText += ' Access level required is "' + cmdInfo.mod.acl.join('/') +
-			'" but user access level is "' + state.acl.join('/') + '".';
+			logEntry
+				.details('Access level required is "' + cmdInfo.mod.acl.join('/'))
+				.details('" but user access level is "' + state.acl.join('/'));
 		} else {
-			errorText += ' No acl is defined, therefore no users are allowed to access this user command.';
+			logEntry.details('No acl is defined, therefore no users are allowed to access this user command.');
 		}
 
-		logger.info(errorText);
+		// Log the entry
+		logEntry.log('User command access level not satisfied');
 
 		return state.error('auth', null, function () {
 			// close the state and send the response


### PR DESCRIPTION
This provides more structured log data and elevates the log
level of the entry. This should help both during development
to make the ACL level error stand out visually, and in
production to make such errors easier to find.

Fixes #25