### PR TITLE
Fix "hosts" configuration for Couchbase client

### DIFF
--- a/lib/archivist/vaults/couchbase/Readme.md
+++ b/lib/archivist/vaults/couchbase/Readme.md
@@ -74,7 +74,7 @@ config:
     options:
         user: Administrator         # optional, usually not required
         password: "password"        # optional, usually not required
-        host: [ "localhost:8091" ]  # optional
+        hosts: [ "localhost:8091" ] # optional
         bucket: default             # optional
     prefix: "prefix for all keys"   # eg: "bob/"
     flagStyle: default              # "default" or "node-memcached"


### PR DESCRIPTION
Over time, this entry has changed, and we are no longer compatible with calling it "host". The property must be named "hosts".

I ran into this the hard way, and I'm on the version that is mentioned by our peer dependency.