### PR TITLE
ts: default export/require default

### DIFF
--- a/lib/commandCenter/commandCenter.js
+++ b/lib/commandCenter/commandCenter.js
@@ -156,6 +156,12 @@ CommandCenter.prototype.setupUserCommandFromDisk = function (modName, modPath, c
  * @param {Object} cmd       The full user command implementation (ie: the result of calling require(userCommandFile))
  */
 CommandCenter.prototype.setupUserCommand = function (modName, cmdName, cmd) {
+	// This is required for TypeScript project where you might want to
+	// be able to `export default [user command code]`
+	if (cmd.default) {
+		cmd = cmd.default;
+	}
+
 	const logDetails = {
 		module: {
 			name: modName,
@@ -171,7 +177,9 @@ CommandCenter.prototype.setupUserCommand = function (modName, cmdName, cmd) {
 		throw new UserCommandSetupError('Command name must be a string', logDetails);
 	}
 
-	if (!cmd || typeof cmd !== 'object') {
+	// typeof may be a function in the case where the user command is defined as a class
+	// with static methods
+	if (!cmd || (typeof cmd !== 'object' && typeof cmd !== 'function')) {
 		throw new UserCommandSetupError('Command must be an object', logDetails);
 	}
 
@@ -187,19 +195,13 @@ CommandCenter.prototype.setupUserCommand = function (modName, cmdName, cmd) {
 	// Is command async?
 	const isAsync = Object.getPrototypeOf(cmd.execute)[Symbol.toStringTag] === 'AsyncFunction';
 
-	// Legacy warning
-	if (cmd.params) {
-		logger.warning
-			.data(logDetails)
-			.log('You no longer need to specify params in your user commands');
-	}
-
 	// Parameters extraction
 	const params = functionArguments(cmd.execute);
 	const firstParameter = params.shift();
 
-	// Sanity check
-	if (params.length !== 0 && firstParameter !== 'state') {
+	// Sanity check - the _state is a standard linting rule in TypeScript
+	// for unused variables
+	if (params.length !== 0 && firstParameter !== 'state' && firstParameter !== '_state') {
 		throw new UserCommandSetupError('execute()\'s first argument must be "state"', logDetails);
 	}
 
@@ -224,7 +226,10 @@ CommandCenter.prototype.setupUserCommand = function (modName, cmdName, cmd) {
 		cmdName: cmdName,
 		cmdPathSplitter: COMMAND_PATH_SPLITTER,
 		mod: cmd,
-		params: params,
+		// Params can be manually specified - this is mostly useful
+		// for external wrapper libraries which may be using the rest
+		// operator
+		params: cmd.params || params,
 		isAsync: isAsync
 	};
 };

--- a/lib/mage/Mage.js
+++ b/lib/mage/Mage.js
@@ -426,6 +426,12 @@ Mage.prototype.useModules = function () {
 				modulePath: resolved
 			}).log('Module "' + name + '" has no implementation.');
 		} finally {
+			// This is required for TypeScript project where you might want to
+			// be able to `export default [user command code]`
+			if (mod.default) {
+				mod = mod.default;
+			}
+
 			this[name] = this.core.modules[name] = mod;
 		}
 	}

--- a/test/commandCenter.js
+++ b/test/commandCenter.js
@@ -61,6 +61,28 @@ describe('commandCenter', function () {
 
 				cc.setupUserCommand('user', 'login', mod);
 			});
+
+			it('If exports.default is present, its content is used for the user command (for TypeScript)', function () {
+				const mod = {
+					default: {
+						execute: function (state, cb) {
+							cb();
+						}
+					}
+				};
+
+				cc.setupUserCommand('user', 'login', mod);
+			});
+
+			it('User commands may be classes with static methods', function () {
+				class mod {
+					static execute(state, cb) {
+						cb();
+					}
+				};
+
+				cc.setupUserCommand('user', 'login', mod);
+			});
 		});
 
 		describe('getPublicConfig()', function () {


### PR DESCRIPTION
The goal of this commit is to allow for user commands
and module definition through the `export default` TypeScript
syntax, which is a bit cleaner than `export =`.

@ronkorving I just dropped the code like that because honestly, I am not entirely sure how to approach this one - but overall this would do what I want.