### PR TITLE
archivist.loaded

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -4,6 +4,15 @@ declare type VaultOperation = 'add' | 'set' | 'del' | 'touch';
 
 declare class Archivist {
     /**
+     * Contains an in-memory copy of all the
+     * VaultValue loaded by this instance.
+     *
+     * @type {{ [key: string]: mage.archivist.IVaultValue }}
+     * @memberof Archivist
+     */
+    loaded: { [key: string]: mage.archivist.IVaultValue }
+
+    /**
      * Check whether a given exists in any of our vaults
      *
      * @param {string} topicName


### PR DESCRIPTION
Exposing this will allow developers to directly have a look at
what archivist has manipulated when writing unit tests.