### PR TITLE
This fixes an edge case in "optional module implementation"

### DIFF
--- a/lib/mage/Mage.js
+++ b/lib/mage/Mage.js
@@ -352,6 +352,27 @@ Mage.prototype.addModulesPath = function (modPath) {
 
 
 /**
+ * Checks if a module exists at a given path (looking for index.ext files)
+ *
+ * @param {string} modPath  A path to a module
+ * @return {boolean}        Returns true if a module exists at the given path, false otherwise.
+ */
+
+function moduleExistsAtPath(modPath) {
+	for (var i = 0; i < CODE_EXTENSIONS.length; i += 1) {
+		var fileName = 'index' + CODE_EXTENSIONS[i];
+		var filePath = path.join(modPath, fileName);
+
+		if (fs.existsSync(filePath)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+
+/**
  * Use a module, either from a path you have specified with `addModulesPath`, or from the modules
  * provided by mage. Modules are searched for in the paths in the order the paths were added, and
  * mage internal modules are search last. This function takes any number of module names as
@@ -368,7 +389,11 @@ Mage.prototype.useModules = function () {
 		modList = modList.concat(arguments[n]);
 	}
 
-	// Iterate over the arguments
+	// If a module cannot be found in the search paths, it may be a mage module
+
+	var mageModulePath = path.resolve(__dirname, '..', 'modules');
+	var modulePaths = this._modulePaths.concat(mageModulePath);
+
 	for (var i = 0; i < modList.length; i++) {
 		var name = modList[i];
 		var resolved = null;
@@ -385,8 +410,9 @@ Mage.prototype.useModules = function () {
 		}
 
 		// Check for module that resolves in the search paths
-		for (var k = 0; k < this._modulePaths.length; k++) {
-			var resolvedPath = path.resolve(this._modulePaths[k], name);
+
+		for (var k = 0; k < modulePaths.length; k++) {
+			var resolvedPath = path.resolve(modulePaths[k], name);
 
 			if (fs.existsSync(resolvedPath)) {
 				resolved = resolvedPath;
@@ -394,45 +420,42 @@ Mage.prototype.useModules = function () {
 			}
 		}
 
-		// If no module was found in the search paths, treat it as a mage module
-		if (!resolved) {
-			resolved = path.join(__dirname, '..', 'modules', name);
-		}
+		this.core.logger.debug('Registering module', name);
 
 		// load configuration
 
 		this.core.config.loadModuleConfig(name, resolved);
 
-		// expose the module
+		// load the module
 
-		this.core.logger.debug('Registering module', name);
+		var mod;
 
-		this._modulesList.push({ name: name, path: resolved });
-		this._setupQueue.push(name);
-
-		var mod = {};
-
-		try {
+		if (moduleExistsAtPath(resolved)) {
 			mod = require(resolved);
-		} catch (error) {
-			if (error.code !== 'MODULE_NOT_FOUND') {
-				error.module = name;
-				error.moduleFile = resolved;
-				throw error;
-			}
+		} else {
+			mod = {};
 
 			this.core.logger.warning.data({
 				moduleName: name,
 				modulePath: resolved
 			}).log('Module "' + name + '" has no implementation.');
-		} finally {
-			// This is required for TypeScript project where you might want to
-			// be able to `export default [user command code]`
-			if (mod.default) {
-				mod = mod.default;
-			}
+		}
 
-			this[name] = this.core.modules[name] = mod;
+		// This is required for TypeScript project where you might want to
+		// be able to `export default [user command code]`
+
+		if (mod.default) {
+			mod = mod.default;
+		}
+
+		// expose the module
+
+		this[name] = this.core.modules[name] = mod;
+
+		this._modulesList.push({ name: name, path: resolved });
+
+		if (mod.setup) {
+			this._setupQueue.push(name);
 		}
 	}
 
@@ -457,8 +480,8 @@ Mage.prototype.useApplicationModules = function () {
 /**
  * Returns the path of a module registered with mage under a given name.
  *
- * @param  {String}      name Module name.
- * @return {String|Null}      Path to the module. Returns null if the module name is not registered.
+ * @param  {string} name Module name.
+ * @return {string}      Path to the module. Throws if the module name is not registered.
  */
 
 Mage.prototype.getModulePath = function (name) {
@@ -524,10 +547,6 @@ Mage.prototype.setupModules = function (cb) {
 		function (callback) {
 			var name = queue.shift();
 			var mod = modules[name];
-
-			if (!mod || !mod.setup) {
-				return callback();
-			}
 
 			var called = false;
 			var timeout = setTimeout(function () {


### PR DESCRIPTION
Before, the following pattern would be considered a "no implementation" wrongfully:

> lib/modules/foo/index.js:

```js
require('non-existing-module'); // this will throw
```

Kinda out-of-scope, but I also optimized a bit how we `setupModules`. Now, the setup queue is not appended to if we know the module doesn't have a `setup` function.

I have tested this patch successfully on a project.