### PR TITLE
type: move msgServer into mage.core

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -1148,6 +1148,125 @@ declare class Mage extends NodeJS.EventEmitter {
         }
 
         /**
+         * The core logger is the logger instance used internally
+         * by MAGE to log different events; for your application,
+         * you should most likely use `mage.logger` instead
+         */
+        logger: Logger;
+
+        /**
+         * Message Server
+         *
+         * The message server is used for state propagation across
+         * multiple MAGE servers in a cluster; it can also be used directly
+         * by MAGE developer to transfer data across servers.
+         *
+         * @memberof Mage
+         */
+        msgServer: {
+            /**
+             * Message Server
+             */
+            mmrp: {
+                Envelope: MmrpEnvelope;
+                MmrpNode: MmrpNode;
+            }
+
+            /**
+             * Check whether the Message Server is enabled
+             *
+             * See https://mage.github.io/mage/api.html#subsystems
+             * for mor details on how to enable message server.
+             *
+             * @returns {boolean}
+             */
+            isEnabled(): boolean;
+
+            /**
+             * Retrieve the underlying MMRP Node instance
+             * used by this Message Server instance.
+             *
+             * @returns {MmrpNode}
+             */
+            getMmrpNode(): MmrpNode;
+
+            /**
+             * Retrieve the unique cluster identifier
+             *
+             * @returns {string}
+             */
+            getClusterId(): string;
+
+            /**
+             * Retreive the configuration used by this Message
+             * Server instance
+             *
+             * @returns {*}
+             */
+            getPublicConfig(): any;
+
+            /**
+             * Get the URL to use to connect to this Message
+             * Stream's instance
+             *
+             * @returns {string}
+             */
+            getMsgStreamUrl(): string;
+
+            /**
+             * Send a message to a remote Message Server instance
+             *
+             * @param {string} address
+             * @param {string} clusterId
+             * @param {MmrpEnvelope} message
+             */
+            send(address: string, clusterId: string, message: MmrpEnvelope): void;
+
+            /**
+             * Broadcast a message to all connected Message Server instance
+             *
+             * @param {MmrpEnvelope} message
+             */
+            broadcast(message: MmrpEnvelope): void;
+
+            /**
+             * Send a confirmation message
+             *
+             * @param {string} address
+             * @param {string} clusterId
+             * @param {string[]} msgIds
+             */
+            confirm(address: string, clusterId: string, msgIds: string[]): void;
+
+            /**
+             * Mark a given address as connected
+             *
+             * @param {string} address
+             * @param {string} clusterId
+             * @param {('never' | 'always' | 'ondelivery')} [disconnects]
+             */
+            connect(address: string, clusterId: string, disconnects?: 'never' | 'always' | 'ondelivery'): void;
+
+            /**
+             * Mark a given address as disconnected
+             *
+             * @param {string} address
+             * @param {string} clusterId
+             */
+            disconnect(address: string, clusterId: string): void;
+
+            /**
+             * Close the network connection for this Message Server
+             */
+            close(): void;
+
+            on(eventName: string, onEvent: (envelope: MmrpEnvelope) => void): void;
+            once(eventName: string, onEvent: (envelope: MmrpEnvelope) => void): void;
+            removeAllListeners(eventName: string): void;
+            removeListener(eventName: string, callback: Function): void;
+        }
+
+        /**
          * Sampler core module
          *
          * Used for keeping tracks of local server metrics. This is useful
@@ -1222,118 +1341,6 @@ declare class Mage extends NodeJS.EventEmitter {
      * @memberOf Mage
      */
     logger: Logger;
-
-    /**
-     * Message Server
-     *
-     * The message server is used for state propagation across
-     * multiple MAGE servers in a cluster; it can also be used directly
-     * by MAGE developer to transfer data across servers.
-     *
-     * @memberof Mage
-     */
-    msgServer: {
-        /**
-         * Message Server
-         */
-        mmrp: {
-            Envelope: MmrpEnvelope;
-            MmrpNode: MmrpNode;
-        }
-
-        /**
-         * Check whether the Message Server is enabled
-         *
-         * See https://mage.github.io/mage/api.html#subsystems
-         * for mor details on how to enable message server.
-         *
-         * @returns {boolean}
-         */
-        isEnabled(): boolean;
-
-        /**
-         * Retrieve the underlying MMRP Node instance
-         * used by this Message Server instance.
-         *
-         * @returns {MmrpNode}
-         */
-        getMmrpNode(): MmrpNode;
-
-        /**
-         * Retrieve the unique cluster identifier
-         *
-         * @returns {string}
-         */
-        getClusterId(): string;
-
-        /**
-         * Retreive the configuration used by this Message
-         * Server instance
-         *
-         * @returns {*}
-         */
-        getPublicConfig(): any;
-
-        /**
-         * Get the URL to use to connect to this Message
-         * Stream's instance
-         *
-         * @returns {string}
-         */
-        getMsgStreamUrl(): string;
-
-        /**
-         * Send a message to a remote Message Server instance
-         *
-         * @param {string} address
-         * @param {string} clusterId
-         * @param {MmrpEnvelope} message
-         */
-        send(address: string, clusterId: string, message: MmrpEnvelope): void;
-
-        /**
-         * Broadcast a message to all connected Message Server instance
-         *
-         * @param {MmrpEnvelope} message
-         */
-        broadcast(message: MmrpEnvelope): void;
-
-        /**
-         * Send a confirmation message
-         *
-         * @param {string} address
-         * @param {string} clusterId
-         * @param {string[]} msgIds
-         */
-        confirm(address: string, clusterId: string, msgIds: string[]): void;
-
-        /**
-         * Mark a given address as connected
-         *
-         * @param {string} address
-         * @param {string} clusterId
-         * @param {('never' | 'always' | 'ondelivery')} [disconnects]
-         */
-        connect(address: string, clusterId: string, disconnects?: 'never' | 'always' | 'ondelivery'): void;
-
-        /**
-         * Mark a given address as disconnected
-         *
-         * @param {string} address
-         * @param {string} clusterId
-         */
-        disconnect(address: string, clusterId: string): void;
-
-        /**
-         * Close the network connection for this Message Server
-         */
-        close(): void;
-
-        on(eventName: string, onEvent: (envelope: MmrpEnvelope) => void): void;
-        once(eventName: string, onEvent: (envelope: MmrpEnvelope) => void): void;
-        removeAllListeners(eventName: string): void;
-        removeListener(eventName: string, callback: Function): void;
-    }
 
     /**
      * Session module

--- a/types.d.ts
+++ b/types.d.ts
@@ -425,7 +425,15 @@ declare type MmrpEnvelopeRoute = string[]
  * @class MmrpEnvelope
  */
 declare class MmrpEnvelope {
-    constructor(eventName: string, messages: MmrpEnvelopeMessage[], route: MmrpEnvelopeRoute, returnRoute: MmrpEnvelopeRoute, flags: MmrpEnvelopeFlag | MmrpEnvelopeFlag[]);
+    constructor(eventName: string, messages: MmrpEnvelopeMessage[], route?: MmrpEnvelopeRoute, returnRoute?: MmrpEnvelopeRoute, flags?: MmrpEnvelopeFlag | MmrpEnvelopeFlag[]);
+
+    /**
+     * List of messages
+     *
+     * @type {MmrpEnvelopeMessage[]}
+     * @memberof MmrpEnvelope
+     */
+    public messages: MmrpEnvelopeMessage[]
 
     /**
      * Sets the message part(s) of the envelope
@@ -637,12 +645,17 @@ declare class MmrpNode {
      * @param {string} [routingStyle]   "*" (to all relays and clients), "*:c" (to all clients), "*:r" (to all peer relays)
      * @return {number}                 Number of bytes sent
      */
-    broadcast(envelope: MmrpEnvelope, routingStyle: string): number;
+    broadcast(envelope: MmrpEnvelope, routingStyle?: string): number;
 
     /**
      * Closes all sockets on this node and removes all event listeners as we won't be emitting anymore.
      */
     close(): void;
+
+    on(eventName: string, onEvent: (envelope: MmrpEnvelope) => void): void;
+    once(eventName: string, onEvent: (envelope: MmrpEnvelope) => void): void;
+    removeAllListeners(eventName: string): void;
+    removeListener(eventName: string, callback: Function): void;
 }
 
 /**
@@ -1168,8 +1181,8 @@ declare class Mage extends NodeJS.EventEmitter {
              * Message Server
              */
             mmrp: {
-                Envelope: MmrpEnvelope;
-                MmrpNode: MmrpNode;
+                Envelope: typeof MmrpEnvelope;
+                MmrpNode: typeof MmrpNode;
             }
 
             /**
@@ -1259,11 +1272,6 @@ declare class Mage extends NodeJS.EventEmitter {
              * Close the network connection for this Message Server
              */
             close(): void;
-
-            on(eventName: string, onEvent: (envelope: MmrpEnvelope) => void): void;
-            once(eventName: string, onEvent: (envelope: MmrpEnvelope) => void): void;
-            removeAllListeners(eventName: string): void;
-            removeListener(eventName: string, callback: Function): void;
         }
 
         /**
@@ -1873,6 +1881,27 @@ declare namespace mage {
             acl?: string[];
             execute<T>(state: IState, ...args: any[]): Promise<T>;
         }
+
+        /**
+         * Logger interface
+         *
+         * This is useful when you wish, for instance, to add a logger
+         * instance to a class.
+         *
+         * ```typescript
+         * class MyClass {
+         *   private _logger: mage.core.ILogger
+         *
+         *   constructor() {
+         *     this._logger = mage.logger.context('MyClass')
+         *   }
+         * }
+         * ```
+         *
+         * @interface ILogger
+         * @extends {Logger}
+         */
+        interface ILogger extends Logger {}
 
         export interface IState {
             /**


### PR DESCRIPTION
For some reason, this was misplaced. Also adding
a reference to `mage.core.logger`, so to make it accessible
to typescript devs.