### PR TITLE
graceful worker exit from worker

### DIFF
--- a/lib/processManager/processManager.js
+++ b/lib/processManager/processManager.js
@@ -157,7 +157,7 @@ WorkerManager.prototype.setupWorkerPhaseManagement = function () {
 	cluster.on('exit', function (worker, code, signal) {
 		var info = '(pid: ' + worker.process.pid + ', code: ' + code + ', signal: ' + signal + ')';
 
-		if (worker._mageManagedExit) {
+		if (worker._mageManagedExit || code === 0) {
 			logger.verbose('Worker', worker.id, 'committed graceful suicide', info);
 		} else {
 			logger.alert('Worker', worker.id, 'died unexpectedly!', info);


### PR DESCRIPTION
In some cases, a developer might want to be able to
shut down a worker and have it respawned by the master
process. By also taking into consideration
the error code, we can now allow for this behavior.