### PR TITLE
Have the start command output stderr when failing

### DIFF
--- a/lib/daemon/index.js
+++ b/lib/daemon/index.js
@@ -105,7 +105,7 @@ function App(runstate, pid) {
 }
 
 
-function sendSignal(pid, signal, timeoutMsec, cb) {
+function sendSignal(app, signal, timeoutMsec, cb) {
 	var timeout, sigSuccessHandler, sigProgressHandler, sigFailedHandler;
 
 	function done(exitCode) {
@@ -144,6 +144,7 @@ function sendSignal(pid, signal, timeoutMsec, cb) {
 
 	// Request failed
 	sigFailedHandler = function () {
+		app.stderr.pipe(process.stderr);
 		err(chalk.red.bold('Failed.'));
 		done(EXIT_FAILED);
 	};
@@ -156,9 +157,9 @@ function sendSignal(pid, signal, timeoutMsec, cb) {
 	process.on(RESP_SUCCESS, sigSuccessHandler);
 	process.on(RESP_FAILED, sigFailedHandler);
 
-	if (pid && signal) {
+	if (app && app.pid && signal) {
 		try {
-			process.kill(pid, signal);
+			process.kill(app.pid, signal);
 		} catch (e) {
 			err(chalk.yellow.bold('Process has gone away'));
 			done(EXIT_FAILED);
@@ -174,38 +175,34 @@ function start(app, cb) {
 		return cb(EXIT_SUCCESS);
 	}
 
-	var appName = process.argv[0];
+	var appName = mage.rootPackage.name;
+	var moduleFile = process.argv[1];
 
 	// copy the args, but remove the "start" or "restart" command
 
-	var args = process.argv.slice(1).filter(function (arg) {
+	var args = process.argv.slice(2).filter(function (arg) {
 		return arg !== 'start' && arg !== 'restart' && arg !== 'reload';
 	});
 
 	// spawn the process
 
-	var spawn = require('child_process').spawn;
+	var fork = require('child_process').fork;
 
-	var child = spawn(process.execPath, args, {
-		detached: true,
-		stdio: 'ignore'
+	var child = fork(moduleFile, args, {
+		silent: true
 	});
 
 	// assign the PID to the app
 
 	app.pid = child.pid;
+	app.stderr = child.stderr;
 
 	out(chalk.green.bold('Starting "' + appName + ' ' + args.join(' ') + '"... (pid: ' + child.pid + ')'));
 
 	// wait for a signal from the child process before we continue
 
-	sendSignal(null, null, timeouts.start, function (exitCode) {
-		// don't count the spawned app in the reference count of the daemonizer
-
-		child.unref();
-
+	sendSignal(app, null, timeouts.start, function (exitCode) {
 		app.runstate = STATUS_RUNNING;
-
 		cb(exitCode);
 	});
 }
@@ -220,7 +217,7 @@ function stop(app, cb) {
 
 	out(chalk.green.bold('Stopping... (pid: ' + app.pid + ')'));
 
-	sendSignal(app.pid, CMD_QUIT, timeouts.stop, function (exitCode) {
+	sendSignal(app, CMD_QUIT, timeouts.stop, function (exitCode) {
 		// EXIT_FAILED still means the app shut down, but there was an error during shutdown. The
 		// app should have logged the error. Because the app has still shut down, we turn will
 		// report a shutdown success by returning EXIT_SUCCESS.
@@ -250,7 +247,7 @@ function reload(app, cb) {
 
 	out(chalk.green.bold('Reloading... (pid: ' + app.pid + ')'));
 
-	sendSignal(app.pid, CMD_RELOAD, timeouts.reload, cb);
+	sendSignal(app, CMD_RELOAD, timeouts.reload, cb);
 }
 
 
@@ -416,7 +413,27 @@ function removeSocketFiles() {
 // We set up some critical event listeners on the master process, so that we signal back to
 // daemonizer processes to report the status of their requests.
 
-exports.appMaster = function () {
+exports.init = function () {
+	var processManager = require('../processManager');
+
+	// Disable stdout/stderr if we are starting daemonized
+	processManager.once('started', function () {
+		var commandPid = getFilePid(CMD_LOCK_FILE);
+
+		if (commandPid) {
+			const {
+				stdout,
+				stderr
+			} = process;
+
+			stdout.write = () => false;
+			stderr.write = () => false;
+		}
+	});
+
+
+	// listen for workers being spawned
+
 	// only the master of a cluster communicates with the daemon commander
 
 	if (!cluster.isMaster) {
@@ -442,10 +459,6 @@ exports.appMaster = function () {
 	} catch (error) {
 		err(chalk.red.bold('Error while trying to clean up .sock files:'), error);
 	}
-
-	// listen for workers being spawned
-
-	var processManager = require('../processManager');
 
 	processManager.once('started', function () {
 		notifyCommander(RESP_SUCCESS);

--- a/lib/tasks/serve.js
+++ b/lib/tasks/serve.js
@@ -7,7 +7,7 @@ exports.setup = function (mage, options, cb) {
 	// set up the appMaster logic on the daemonizor, creating a PID file, etc.
 
 	function setupDaemonizerCallbacks(callback) {
-		require('../daemon').appMaster();
+		require('../daemon').init();
 		callback();
 	}
 


### PR DESCRIPTION
Currently when the start command fails the use will be greeted by this quite not helpful message:

```haskell
$ npm run start

> my-awesome-project@1.0.0 start /my/awesome/project
> echo             'Start MAGE as a daemon'                 && mage start

Start MAGE as a daemon
Starting "/path/to/node /my/awesome/project/node_modules/.bin/mage"... (pid: 999)
Failed.
```

This changes has the deamonizer keep `stderr` on the child as a pipe, and if an error occur will pipe it to the current processes `stderr`:

```haskell
$ npm run start

> my-awesome-project@1.0.0 start /my/awesome/project
> echo             'Start MAGE as a daemon'                 && mage start

Start MAGE as a daemon
Starting "/path/to/node /my/awesome/project/node_modules/.bin/mage"... (pid: 1000)
Failed.

m-1000 - 13:37:32.171     <debug> [MAGE archivist] Creating persistent vaults ["volatileVault","userVault"]
... snip ...
m-1000 - 13:37:32.177 <emergency> [MAGE] Error during MAGE setup: No valid IPv4 found on interface invalid
  data: {
    "file": "index.js",
    "line": 39,
    "offset": 10,
    "type": "Error",
    "stack": [ "... snip ..." ]
  }
m-1000 - 13:37:32.177     <debug> [MAGE] Shutting down Mage...
m-1000 - 13:37:32.179     <debug> [MAGE archivist] Closing all vaults...
m-1000 - 13:37:32.181     <debug> [MAGE] Destroying all log writers
