### PR TITLE
Fixes logging of objects that don't have a prototype

### DIFF
--- a/lib/loggingService/LogEntry.js
+++ b/lib/loggingService/LogEntry.js
@@ -11,7 +11,7 @@ var ServerResponse = require('http').ServerResponse;
 
 
 function serializeAny(obj, refList) {
-	var out;
+	var out, i;
 
 	refList = refList || [];
 
@@ -26,7 +26,7 @@ function serializeAny(obj, refList) {
 
 		out = new Array(len);
 
-		for (var i = 0; i < len; i++) {
+		for (i = 0; i < len; i++) {
 			out[i] = serializeAny(obj[i], refList);
 		}
 
@@ -76,10 +76,17 @@ function serializeAny(obj, refList) {
 
 		out = {};
 
-		for (var key in obj) {
-			if (obj.hasOwnProperty(key)) {
-				out[key] = serializeAny(obj[key] ? obj[key].valueOf() : obj[key], refList);
+		var keys = Object.keys(obj);
+
+		for (i = 0; i < keys.length; i += 1) {
+			var key = keys[i];
+			var value = obj[key];
+
+			if (value && value.valueOf) {
+				value = value.valueOf();
 			}
+
+			out[key] = serializeAny(value, refList);
 		}
 
 		return out;


### PR DESCRIPTION
Fixes #79 

This fixes both the `.hasOwnProperty()` issue, and the `.valueOf()` issue. Tested in the wild.

I would love to add unit tests for this, but I'm in crunch mode on my project and there is no test suite for the logger yet (so would be a little bit more than trivial). For what it's worth have successfully tested this to work on real production code. I do consider this PR to be high priority for obvious reasons (it's blowing up my app).

With regards to unit testing by the way, we do run log entries during the test suite, and it's touching the code I wrote, because coverage is actually increasing, which only makes sense if the lines I wrote (and this PR adds more lines than it removes) are touched.