### PR TITLE
Let consul default on the first interface when not configured

### DIFF
--- a/lib/serviceDiscovery/engines/consul/Readme.md
+++ b/lib/serviceDiscovery/engines/consul/Readme.md
@@ -19,7 +19,7 @@ use a different service.
 ### Configuration
 
 In the `server.serviceDiscovery.options` object the following options exists:
- - __interface (required)__: The interface to advertise, such as `eth0` or `enp4s0`.
+ - __interface (optional)__: The interface to advertise, such as `eth0` or `enp4s0`, defaults to first available interface.
  - __ttl (optional)__: The interval at which we should renew our consul session in milliseconds. If the server
             crashes hard the advertisement will be removed after this TTL expires. Defaults to 30000.
  - __consul (optional)__: Options to pass to the `node-consul` module, see [the documentation](https://github.com/silas/node-consul#consuloptions).

--- a/lib/serviceDiscovery/engines/consul/index.js
+++ b/lib/serviceDiscovery/engines/consul/index.js
@@ -24,7 +24,25 @@ class ConsulService extends Service {
 		super();
 
 		if (!options.interface) {
-			throw new Error('Missing "interface" option for consul module');
+			// find the first interface with a valid IPv4
+			let validIface;
+
+			const interfaces = os.networkInterfaces();
+			for (const iface of Object.keys(interfaces)) {
+				if (interfaces[iface].filter(v => v.family === 'IPv4').length) {
+					validIface = iface;
+					break;
+				}
+			}
+
+			if (!validIface) {
+				throw new Error('No valid interface found on this device');
+			}
+
+			// take the first one
+			options.interface = validIface;
+
+			logger.warning(`No interface defined for consul, defaulting to ${options.interface}`);
 		}
 
 		this.name = name;


### PR DESCRIPTION
The restrictive nature of the consul module right now makes it hard on developers since based on the environment the interface might be different.

This fixes it by making it possible to omit the consul interface, in this configuration it will pick the first available interface and emit a warning instead of crashing hard.