### PR TITLE
Fixes command center logging when ACL test fails

### DIFF
--- a/lib/commandCenter/commandCenter.js
+++ b/lib/commandCenter/commandCenter.js
@@ -510,8 +510,8 @@ CommandCenter.prototype.executeCommand = function (cmd, session, metaData, cb) {
 		// Add some log details depending on whether the command defines ACLs
 		if (cmdInfo.mod.acl) {
 			logEntry
-				.details('Access level required is "' + cmdInfo.mod.acl.join('/'))
-				.details('" but user access level is "' + state.acl.join('/'));
+				.details('Access level required is "' + cmdInfo.mod.acl.join('/') + '",')
+				.details('but user access level is "' + state.acl.join('/') + '"');
 		} else {
 			logEntry.details('No acl is defined, therefore no users are allowed to access this user command.');
 		}


### PR DESCRIPTION
This log entry was poorly formatted. It was:

```
Access level required is "admin
" but user access level is "user
```

Note the missing quotation mark at the end, and the misplaced quotation mark after `admin`.
Output is now:

```
Access level required is "admin",
but user access level is "user"
```

Keep in mind that every call to `.details()` doesn't just concatenate, it also creates a newline.