### PR TITLE
Update public config to pass cors in the right locations

### DIFF
--- a/lib/commandCenter/commandCenter.js
+++ b/lib/commandCenter/commandCenter.js
@@ -301,9 +301,11 @@ CommandCenter.prototype.setup = function () {
 CommandCenter.prototype.getPublicConfig = function (baseUrl) {
 	const cfg = {
 		url: baseUrl + '/' + this.app.name,
-		cors: mage.core.httpServer.getCorsConfig(),
 		timeout: 15000,
-		commands: {}
+		commands: {},
+		httpOptions: {
+			cors: mage.core.httpServer.getCorsConfig()
+		}
 	};
 
 	const execPaths = Object.keys(this.commands);

--- a/lib/msgServer/index.js
+++ b/lib/msgServer/index.js
@@ -125,7 +125,9 @@ exports.getPublicConfig = function (baseUrl) {
 		var type = types[i];
 		var transportConfig = cfgMsgStream.transports[type];
 
-		cfg.transports[type] = {};
+		cfg.transports[type] = {
+			cors: cfg.cors
+		};
 
 		var keys = Object.keys(transportConfig);
 		for (var j = 0; j < keys.length; j += 1) {


### PR DESCRIPTION
Related to [mage/mage-sdk-js#5](https://github.com/mage/mage-sdk-js/pull/5)

This changes `getPublicConfig` in both the `commandCenter` and `msgServer` to pass around the `cors` configuration to transports.

This currently prevents stick sessions from working on AWS ELB.