### PR TITLE
Consul: Reduce session expiration message to warning

### DIFF
--- a/lib/serviceDiscovery/engines/consul/index.js
+++ b/lib/serviceDiscovery/engines/consul/index.js
@@ -231,12 +231,13 @@ class ConsulService extends Service {
 	_keepalive(sessionId) {
 		this._consul.session.renew(sessionId, (err) => {
 			if (err) {
-				logger.error.data(err).log(`Failed to renew session ${this._sessionId}`);
-
 				// session might have expired without us wanting it, renew all announcements
 				if (err.statusCode === 404) {
+					logger.warning.data(err).log(`Session ${this._sessionId} not found, reannouncing services`);
 					return this._reannounce();
 				}
+
+				logger.error.data(err).log(`Failed to renew session ${this._sessionId}`);
 			}
 
 			this._keepaliveTimer = setTimeout(this._keepalive.bind(this, sessionId), this.ttl);


### PR DESCRIPTION
As discussed with @ronkorving session expiration can happen in some environments, due for example to clocks drifting or systems going to sleep/hibernation.

Since we can recover from this case downgrade the message to a warning.