### PR TITLE
Suppress two vulnerable packages: growl, brace-expansion

### DIFF
--- a/.retireignore
+++ b/.retireignore
@@ -1,5 +1,6 @@
+@growl
+@brace-expansion
 @hawk
-# jQuery
 node_modules/plato/lib/assets/scripts/vendor/jquery-1.8.3.min.js
 node_modules/plato/tmp/assets/scripts/vendor/jquery-1.8.3.min.js
 node_modules/plato/lib/assets/scripts/bundles/core-bundle.js


### PR DESCRIPTION
While they are unsafe, they are only used in development.

**growl**: We need to wait for a growl release and for mocha to get updated.
**brace-expansion**: This has been fixed, but sqlite3 needs a release to update its dependencies.