### PR TITLE
announce, then discover

### DIFF
--- a/lib/msgServer/index.js
+++ b/lib/msgServer/index.js
@@ -594,10 +594,6 @@ function setupDiscovery() {
 		mmrpNode.relayDown(uri);
 	});
 
-	// start discovering!
-
-	service.discover();
-
 	// announce our relay
 
 	if (mmrpNode.isRelay) {
@@ -617,7 +613,13 @@ function setupDiscovery() {
 			}
 
 			logger.notice('MMRP relay announced on port', port);
+
+			// start discovering!
+			service.discover();
 		});
+	} else {
+		// start discovering!
+		service.discover();
 	}
 }
 


### PR DESCRIPTION
Fixes #28.

Fixes the issue by announcing first, which creates a ZooKeeper node path before we try to read on it.