### PR TITLE
Fix service discovery not being shutdown properly

### DIFF
--- a/lib/msgServer/index.js
+++ b/lib/msgServer/index.js
@@ -642,7 +642,9 @@ exports.setup = function () {
 	setupDiscovery();
 };
 
-exports.close = function () {
+exports.close = function (cb) {
+	cb = cb || (() => {});
+
 	if (mmrpNode) {
 		logger.verbose('Closing MMRP node');
 
@@ -667,10 +669,9 @@ exports.close = function () {
 	if (service) {
 		logger.verbose('Closing service discovery');
 
-		if (service.close) {
-			service.close();
-		}
-
+		service.close(cb);
 		service = null;
+	} else {
+		setImmediate(cb);
 	}
 };

--- a/lib/serviceDiscovery/engines/consul/index.js
+++ b/lib/serviceDiscovery/engines/consul/index.js
@@ -139,7 +139,7 @@ class ConsulService extends Service {
 	/**
 	 * Stop discovery and announcements
 	 */
-	close() {
+	close(cb) {
 		this._announces.length = 0;
 
 		if (this._watch) {
@@ -155,11 +155,17 @@ class ConsulService extends Service {
 		if (this._sessionId) {
 			// just close our session to automatically delete all keys we created
 			this._consul.session.destroy(this._sessionId, (err) => {
-				logger.error.data(err).log(`Failed to release session ${this._sessionId}`);
-			});
-		}
+				if (err) {
+					logger.error.data(err).log(`Failed to release session ${this._sessionId}`);
+				}
 
-		logger.debug('Stopped discovery process');
+				logger.debug('Stopped discovery process');
+				cb();
+			});
+		} else {
+			logger.debug('Stopped discovery process');
+			setImmediate(cb);
+		}
 	}
 
 	/**

--- a/lib/serviceDiscovery/engines/mdns/index.js
+++ b/lib/serviceDiscovery/engines/mdns/index.js
@@ -165,13 +165,15 @@ MDNSService.prototype.discover = function () {
 };
 
 
-MDNSService.prototype.close = function () {
+MDNSService.prototype.close = function (cb) {
 	if (this.advertisement) {
 		this.advertisement.stop();
 		this.advertisement = null;
 	}
 
 	this.browser.stop();
+
+	setImmediate(cb);
 };
 
 

--- a/lib/serviceDiscovery/engines/zookeeper/index.js
+++ b/lib/serviceDiscovery/engines/zookeeper/index.js
@@ -344,7 +344,7 @@ ZooKeeperService.prototype.discover = function () {
 };
 
 
-ZooKeeperService.prototype.close = function () {
+ZooKeeperService.prototype.close = function (cb) {
 	var state = this.client.getState();
 
 	if (this.connectTimer) {
@@ -357,6 +357,8 @@ ZooKeeperService.prototype.close = function () {
 	if (state === zooKeeper.State.SYNC_CONNECTED) {
 		this.client.close();
 	}
+
+	setImmediate(cb);
 };
 
 

--- a/lib/serviceDiscovery/service.js
+++ b/lib/serviceDiscovery/service.js
@@ -38,4 +38,11 @@ Service.prototype.discover = function () {
 	throw new Error('Not implemented');
 };
 
+/**
+ * Stops all functions of the service discovery process, does nothing by default
+ */
+Service.prototype.close = function (cb) {
+	return setImmediate(cb);
+};
+
 exports.Service = Service;

--- a/lib/tasks/serve.js
+++ b/lib/tasks/serve.js
@@ -157,8 +157,7 @@ exports.shutdown = function (mage, options, cb) {
 	}
 
 	function closeMsgServer(callback) {
-		mage.core.msgServer.close();
-		callback();
+		mage.core.msgServer.close(callback);
 	}
 
 	function closeVaults(callback) {


### PR DESCRIPTION
In some cases service discovery shutdown can be asynchronous (ie. `consul`), this adds a callback to the `msgServer.close` function that is passed all the way down to SD, allowing them to exit cleanly.

![image](https://user-images.githubusercontent.com/308493/28506967-26a30216-706a-11e7-858f-3d1f3f750ec3.png)
