### PR TITLE
shutdown: terminate msgStream conns, http conns

### DIFF
--- a/lib/httpServer/transports/http/index.js
+++ b/lib/httpServer/transports/http/index.js
@@ -967,7 +967,13 @@ exports.close = function (cb) {
 
 	logger.debug('Closing HTTP server');
 
+	// Close the server - stop accepting new requests and drain
 	server.close(cb);
+
+	// Let other parts of the system know that the HTTP server
+	// is currently closing; this allows, for instance, for msgStream
+	// to preemptively close current websocket or long-polling connections
+	server.emit('closing');
 };
 
 

--- a/lib/msgServer/msgStream/index.js
+++ b/lib/msgServer/msgStream/index.js
@@ -383,8 +383,6 @@ MsgStream.prototype.bindTransportToHttpServer = function (httpServer, transport)
  */
 
 MsgStream.prototype.bindToHttpServer = function (httpServer) {
-	var that = this;
-
 	// bind transports
 
 	var types = Object.keys(this.cfg.transports || {});
@@ -392,10 +390,7 @@ MsgStream.prototype.bindToHttpServer = function (httpServer) {
 		this.bindTransportToHttpServer(httpServer, types[i]);
 	}
 
-	// server shutdown
+	// on server shutdown, close all open connections
 
-	httpServer.server.on('close', function () {
-		// close all open hosts
-		that.close();
-	});
+	httpServer.server.on('closing', () => this.close());
 };

--- a/lib/msgServer/msgStream/transports/http-polling/index.js
+++ b/lib/msgServer/msgStream/transports/http-polling/index.js
@@ -105,7 +105,7 @@ HttpPollingHost.prototype.deliver = function (msgs) {
 
 
 HttpPollingHost.prototype.respondBadRequest = function (reason) {
-	if (!this.res) {
+	if (this.res.finished) {
 		logger.verbose('Cannot respond bad request (client gone)');
 		return;
 	}
@@ -129,7 +129,7 @@ HttpPollingHost.prototype.respondBadRequest = function (reason) {
 HttpPollingHost.prototype.respondServerError = function () {
 	// used when we fail to confirm a session key for example
 
-	if (!this.res) {
+	if (this.res.finished) {
 		logger.verbose('Cannot respond server error (client gone)');
 		return;
 	}
@@ -191,6 +191,11 @@ HttpPollingHost.prototype.setConnection = function (req, res, query) {
 
 
 HttpPollingHost.prototype.respondToHead = function () {
+	if (this.res.finished) {
+		logger.verbose('Cannot respond to HEAD request (client gone)');
+		return;
+	}
+
 	this.res.writeHead(200, {
 		'content-type': 'application/json',
 		pragma: 'no-cache'
@@ -202,18 +207,17 @@ HttpPollingHost.prototype.respondToHead = function () {
 
 
 HttpPollingHost.prototype._closeConnection = function () {
-	if (!this.res) {
+	if (this.res.finished) {
 		return;
 	}
 
-	this.res = null;
 	this.emit('close');
 	this.removeAllListeners();
 };
 
 
 HttpPollingHost.prototype._sendHeartbeat = function () {
-	if (!this.res) {
+	if (this.res.finished) {
 		return;
 	}
 


### PR DESCRIPTION
This commit kills two birds in one stones (apologies to
the families of the birds):

  1. Fixes #106
  2. Tells the msgStream connections to close preemptively;
     this has the advantage of making the shutdown time
     more consistent.

The second point now happens because we immediately emit a 'closing' event on the http server instance; this is required, because the 'close' event emits once all connections are closed, and so listening to that event to close underlying connections is pointless. By closing-and-emitting, we:

  1. Stop other connections from being accepted
  2. Can terminate long-polling and web socket connections when the 'closing' event is emitted
  3. Once we have manually terminated all outstanding long-polling connections, the http server can now close naturally (and fire both the 'close' event and the attached callback)

Tested on the game where the failure was reported (internal). 