### PR TITLE
do not relay if mmrpNode is closed

### DIFF
--- a/lib/msgServer/index.js
+++ b/lib/msgServer/index.js
@@ -503,6 +503,10 @@ function setupDiscovery() {
 
 
 	service.on('up', function (announced) {
+		if (!mmrpNode) {
+			return;
+		}
+
 		// ignore different mmrp apps
 
 		if (!isNameMatch(announced)) {
@@ -548,6 +552,10 @@ function setupDiscovery() {
 	// relays should disconnect from other relays when they disappear
 
 	service.on('down', function (announced) {
+		if (!mmrpNode) {
+			return;
+		}
+
 		if (!announced) {
 			return logger.verbose('Unknown service went down.');
 		}


### PR DESCRIPTION
Once the mmrp node has been closed, trying to
pipe data from service discovery to it will cause an
uncaught exception.