### PR TITLE
state.emit/broadcast: multiple changes

### DIFF
--- a/docs-sources/includes/_States.md
+++ b/docs-sources/includes/_States.md
@@ -36,7 +36,7 @@ the actions will not be executed; the two `mage.players.register` calls we have 
 would only store information if the call succeded.
 
 For more information about the API you use to access your data store, please read the
-[Archivist](./api/classes/_mage_d_.archivist.html) API documentation.
+[Archivist](./api/classes/archivist.html) API documentation.
 
 ## Transactional event emission
 
@@ -70,4 +70,4 @@ were to return an error, the event emitted by `state.emit` would never be sent t
 player referenced by `playerId`.
 
 For more information on the State API and how events are emitted, please read the
-[State](./api/interfaces/_mage_d_.mage.core.istate.html) API documentation.
+[State](./api/interfaces/mage.core.istate.html) API documentation.

--- a/lib/archivist/vaults/client/Readme.md
+++ b/lib/archivist/vaults/client/Readme.md
@@ -14,10 +14,10 @@ operation | supported | implementation
 ----------|:---------:|---------------
 list      |           |
 get       |           |
-add       | ✔         | `state.emitToActors('archivist:set')`
-set       | ✔         | `state.emitToActors('archivist:set' or 'archivist:applyDiff')`
-touch     | ✔         | `state.emitToActors('archivist:touch')`
-del       | ✔         | `state.emitToActors('archivist:del')`
+add       | ✔         | `state.emit('archivist:set')`
+set       | ✔         | `state.emit('archivist:set' or 'archivist:applyDiff')`
+touch     | ✔         | `state.emit('archivist:touch')`
+del       | ✔         | `state.emit('archivist:del')`
 
 ### Required Topic API
 

--- a/lib/archivist/vaults/client/index.js
+++ b/lib/archivist/vaults/client/index.js
@@ -103,7 +103,7 @@ function emit(vault, event, actorIds, msg) {
 	} else {
 		vault.logger.verbose('Emitting "' + event + '" to', actorIds);
 
-		vault.state.emitToActors(actorIds, event, msg);
+		vault.state.emit(actorIds, event, msg);
 	}
 }
 

--- a/lib/commandCenter/commandCenter.js
+++ b/lib/commandCenter/commandCenter.js
@@ -79,7 +79,6 @@ function CommandCenter(app) {
 	this.app = app;
 	this.exposed = false;
 	this.commands = {};
-	this.userCommandTimeout = null;
 
 	let ttl;
 
@@ -388,15 +387,52 @@ function compress(content, cb) {
 	});
 }
 
+/**
+ * Promisify the user command execute method, or
+ * ensure its return value is passed to state.respond
+ *
+ * Once callback-based user commands are removed from MAGE,
+ * you will be able to remove this method.
+ *
+ * @param {*} cmdInfo
+ * @param {*} paramList
+ */
+function generateCommandPromise(cmdInfo, state, paramList) {
+	const mod = cmdInfo.mod;
+	const execute = mod.execute.apply.bind(mod.execute, mod, paramList);
+
+	if (cmdInfo.isAsync) {
+		// Async user commands will need to take the response value, and feed it
+		// to `state.respond`
+		return execute()
+			.then((response) => state.respond(response, mod.serialize === false));
+	} else {
+		// Callback-based user commands are expected to call `state.respond`
+		// on their own; all we need to do is promisify
+		return new Promise((resolve) => mod.execute(resolve));
+	}
+}
 
 /**
- * Sets the execution timeout of all user commands to the given duration
+ * Create a promise timer
  *
- * @param {number} timeout   Timeout in milliseconds
+ * Useful when using Promise.race.
+ *
+ * @param {*} timeout
  */
-CommandCenter.prototype.setUserCommandTimeout = function (timeout) {
-	this.userCommandTimeout = timeout;
-};
+function createPromiseTimer(timeout) {
+	let timer;
+
+	const promise = new Promise((resolve, reject) => {
+		if (timeout) {
+			timer = setTimeout(() => reject(new Error('timeout')), timeout);
+		}
+	});
+
+	promise.clear = () => clearTimeout(timer);
+
+	return promise;
+}
 
 /**
  * Returns the information about the given command, or undefined if it does not exist.
@@ -468,24 +504,24 @@ CommandCenter.prototype.buildParamList = function (cmdInfoModParams, cmdParams) 
  * @param {Function} cb
  */
 CommandCenter.prototype.executeCommand = function (cmd, session, metaData, cb) {
-	var cmdInfo = this.getCommandInfo(cmd.name);
-	if (!cmdInfo) {
-		// command not registered in this command center
+	const cmdInfo = this.getCommandInfo(cmd.name);
 
+	// Return an error if the user command does not exist
+	if (!cmdInfo) {
 		logger.error('Attempt to execute unregistered user command:', cmd);
 
 		return cb(null, { errorCode: '"server"' });
 	}
 
-	// set up state
-	var state = new State(null, session, {
+	// Set up state
+	const state = new State(null, session, {
 		appName: this.app.name,
 		description: cmd.name,
-		data: metaData,
-		timeout: this.userCommandTimeout
+		data: metaData
 	});
 
-	// check if access control list grants the proper access
+	// Return an error if the user does not have a sufficient right
+	// level to execute this user command
 	if (!state.canAccess(cmdInfo.mod.acl)) {
 		// Create a log entry
 		var logEntry = logger.error.data({
@@ -519,71 +555,62 @@ CommandCenter.prototype.executeCommand = function (cmd, session, metaData, cb) {
 		});
 	}
 
-	var that = this;
-
-	state.archivist.createVault('client', 'client', { state: state }, function () {
-		// execute the command
-
-		logger.debug('Executing user command:', cmdInfo.execPath);
-
-		var mod = cmdInfo.mod;
-
-		var paramList;
+	// Create the client vault, so that events and data may be sent
+	// to the client
+	state.archivist.createVault('client', 'client', { state: state }, () => {
+		// Extract parameters, and return early if the parsing failed
+		let paramList;
 
 		try {
-			paramList = that.buildParamList(cmdInfo.params, cmd.params);
+			paramList = this.buildParamList(cmdInfo.params, cmd.params);
 		} catch (err) {
 			return cb(err);
 		}
 
+		// Debug logging
+		logger.debug
+			.log('Executing user command:', cmdInfo.execPath);
+
+		// Prefix the params list with the state object
 		paramList.unshift(state);
 
-		// time the user command
+		// Set a command timeout, if configured
+		const timer = createPromiseTimer(cmdInfo.mod.timeout);
 
-		var startTime = process.hrtime();
+		// Promisify the user command, if needed
+		const command = generateCommandPromise(cmdInfo, state, paramList);
 
-		// function to run upon completion
-		function onCommandCompleted() {
-			// note: we may not expect an error parameter, the error state should now be known by the state object
+		// Time the user command
+		const startTime = process.hrtime();
 
-			// close the state:
-			// - commits and sends events to other players, or:
-			// - rolls back
+		Promise.race([timer, command])
+			.catch((error) => state.error(error, error))
+			.then(() => {
+				// Clear timeout, if present
+				timer.clear();
 
-			state.close(function (closeError, response) {
-				// use the gathered errors, response, events on the state object to build response JSON for the client
-				// at this time, state.close() never returns a closeError.
+				// Close the state, and respond to the client
+				state.close((closeError, response) => {
+					// use the gathered errors, response, events on the state object
+					// to build response JSON for the client at this time, state.close()
+					// never returns a closeError.
 
-				var durationRaw = process.hrtime(startTime);
-				var duration = durationRaw[0] + durationRaw[1] / 1e9;
+					var durationRaw = process.hrtime(startTime);
+					var duration = durationRaw[0] + durationRaw[1] / 1e9;
 
-				logger.info
-					.data({
-						durationMsec: 1000 * duration,
-						commandName: cmd.name,
-						actorId: state.actorId
-					})
-					.log('Executed user command:', cmd.name);
+					logger.info
+						.data({
+							durationMsec: 1000 * duration,
+							commandName: cmd.name,
+							actorId: state.actorId
+						})
+						.log('Executed user command:', cmd.name);
 
-				exports.emit('completed', that.app, cmd, durationRaw);
+					exports.emit('completed', this.app, cmd, durationRaw);
 
-				cb(null, response);
+					cb(null, response);
+				});
 			});
-		}
-
-		if (cmdInfo.isAsync) {
-			mod.execute.apply(mod, paramList).then(function (response) {
-				state.respond(response, mod.serialize === false);
-			}).catch(function (error) {
-				state.error(error.code, error);
-			}).then(onCommandCompleted);
-		} else {
-			// add the final callback on the params list
-			paramList.push(onCommandCompleted);
-
-			// call the execute function of the usercommand
-			mod.execute.apply(mod, paramList);
-		}
 	});
 };
 

--- a/lib/commandCenter/commandCenter.js
+++ b/lib/commandCenter/commandCenter.js
@@ -478,23 +478,12 @@ CommandCenter.prototype.executeCommand = function (cmd, session, metaData, cb) {
 	}
 
 	// set up state
-
-	var state = new State();
-	state.appName = this.app.name;
-
-	if (this.userCommandTimeout) {
-		state.setTimeout(this.userCommandTimeout);
-	}
-
-	state.setDescription(cmd.name);
-
-	if (session) {
-		state.registerSession(session);
-	}
-
-	if (metaData) {
-		state.data = metaData;
-	}
+	var state = new State(null, session, {
+		appName: this.app.name,
+		description: cmd.name,
+		data: metaData,
+		timeout: this.userCommandTimeout
+	});
 
 	// check if access control list grants the proper access
 	if (!state.canAccess(cmdInfo.mod.acl)) {

--- a/lib/commandCenter/commandCenter.js
+++ b/lib/commandCenter/commandCenter.js
@@ -395,6 +395,7 @@ function compress(content, cb) {
  * you will be able to remove this method.
  *
  * @param {*} cmdInfo
+ * @param {State} state
  * @param {*} paramList
  */
 function generateCommandPromise(cmdInfo, state, paramList) {
@@ -418,9 +419,9 @@ function generateCommandPromise(cmdInfo, state, paramList) {
  *
  * Useful when using Promise.race.
  *
- * @param {*} timeout
+ * @param {number} timeout
  */
-function createPromiseTimer(timeout) {
+function createTimerPromise(timeout) {
 	let timer;
 
 	const promise = new Promise((resolve, reject) => {
@@ -524,7 +525,7 @@ CommandCenter.prototype.executeCommand = function (cmd, session, metaData, cb) {
 	// level to execute this user command
 	if (!state.canAccess(cmdInfo.mod.acl)) {
 		// Create a log entry
-		var logEntry = logger.error.data({
+		const logEntry = logger.error.data({
 			app: this.app.name,
 			module: cmdInfo.mod.name,
 			command: cmd.name,
@@ -568,14 +569,13 @@ CommandCenter.prototype.executeCommand = function (cmd, session, metaData, cb) {
 		}
 
 		// Debug logging
-		logger.debug
-			.log('Executing user command:', cmdInfo.execPath);
+		logger.debug('Executing user command:', cmdInfo.execPath);
 
 		// Prefix the params list with the state object
 		paramList.unshift(state);
 
 		// Set a command timeout, if configured
-		const timer = createPromiseTimer(cmdInfo.mod.timeout);
+		const timer = createTimerPromise(cmdInfo.mod.timeout);
 
 		// Promisify the user command, if needed
 		const command = generateCommandPromise(cmdInfo, state, paramList);
@@ -595,8 +595,8 @@ CommandCenter.prototype.executeCommand = function (cmd, session, metaData, cb) {
 					// to build response JSON for the client at this time, state.close()
 					// never returns a closeError.
 
-					var durationRaw = process.hrtime(startTime);
-					var duration = durationRaw[0] + durationRaw[1] / 1e9;
+					const durationRaw = process.hrtime(startTime);
+					const duration = durationRaw[0] + durationRaw[1] / 1e9;
 
 					logger.info
 						.data({

--- a/lib/commandCenter/commandCenter.js
+++ b/lib/commandCenter/commandCenter.js
@@ -400,17 +400,19 @@ function compress(content, cb) {
  */
 function generateCommandPromise(cmdInfo, state, paramList) {
 	const mod = cmdInfo.mod;
-	const execute = mod.execute.apply.bind(mod.execute, mod, paramList);
+	const execute = () => mod.execute.apply(mod, paramList);
 
 	if (cmdInfo.isAsync) {
 		// Async user commands will need to take the response value, and feed it
 		// to `state.respond`
+		const isJson = mod.serialize === false;
+
 		return execute()
-			.then((response) => state.respond(response, mod.serialize === false));
+			.then((response) => state.respond(response, isJson));
 	} else {
 		// Callback-based user commands are expected to call `state.respond`
 		// on their own; all we need to do is promisify
-		return new Promise((resolve) => mod.execute(resolve));
+		return new Promise((resolve) => execute(resolve));
 	}
 }
 

--- a/lib/commandCenter/commandCenter.js
+++ b/lib/commandCenter/commandCenter.js
@@ -722,7 +722,7 @@ CommandCenter.prototype.executeBatch = function (acceptedEncodings, batch, query
 
 		var session = state.session;
 
-		var headerEvents = state.myEvents;
+		var headerEvents = state.myEvents.map((event) => event.evt);
 
 		// try to load a previously cached response to this query
 

--- a/lib/commandCenter/commandCenter.js
+++ b/lib/commandCenter/commandCenter.js
@@ -427,7 +427,7 @@ function generateCommandPromise(cmdInfo, state, paramList) {
 	} else {
 		// Callback-based user commands are expected to call `state.respond`
 		// on their own; all we need to do is promisify
-		return new Promise((resolve) => execute(resolve));
+		return new Promise((resolve) => paramList.push(resolve) && execute());
 	}
 }
 

--- a/lib/commandCenter/commandCenter.js
+++ b/lib/commandCenter/commandCenter.js
@@ -22,13 +22,28 @@ const CONTENT_TYPE_JSON = 'application/json; charset=UTF-8';
 
 exports = module.exports = new EventEmitter();
 
+/**
+ * Class used when errors occur during setup
+ */
 class UserCommandSetupError extends Error {
 	constructor(message, details) {
 		super(message);
 		Object.assign(this, details);
-		this.name = 'UserCommandSetupError';
+		this.type = 'UserCommandSetupError';
 	}
 };
+
+/**
+ * Class used when a timeout occurs during execution
+ */
+class UserCommandExecutionTimeout extends Error {
+	constructor(commandName) {
+		super('User command timed out');
+		this.userCommandName = commandName;
+		this.type = 'UserCommandExecutionTimeout';
+		this.code = 'timeout';
+	}
+}
 
 
 // message hooks
@@ -423,12 +438,12 @@ function generateCommandPromise(cmdInfo, state, paramList) {
  *
  * @param {number} timeout
  */
-function createTimerPromise(timeout) {
+function createTimerPromise(commandName, timeout) {
 	let timer;
 
 	const promise = new Promise((resolve, reject) => {
 		if (timeout) {
-			timer = setTimeout(() => reject(new Error('timeout')), timeout);
+			timer = setTimeout(() => reject(new UserCommandExecutionTimeout(commandName)), timeout);
 		}
 	});
 
@@ -577,7 +592,7 @@ CommandCenter.prototype.executeCommand = function (cmd, session, metaData, cb) {
 		paramList.unshift(state);
 
 		// Set a command timeout, if configured
-		const timer = createTimerPromise(cmdInfo.mod.timeout);
+		const timer = createTimerPromise(cmd.name, cmdInfo.mod.timeout);
 
 		// Promisify the user command, if needed
 		const command = generateCommandPromise(cmdInfo, state, paramList);

--- a/lib/modules/session/index.js
+++ b/lib/modules/session/index.js
@@ -265,7 +265,7 @@ Session.prototype.delData = function (state, key) {
 // returns msgServer compatible addresses/hosts for actors
 
 exports.getActorAddresses = function (state, actorIds, cb) {
-	var addresses = [];
+	var addresses = {};
 	var options = { optional: true, mediaTypes: ['application/json'] };
 
 	var topic = 'session';
@@ -286,12 +286,12 @@ exports.getActorAddresses = function (state, actorIds, cb) {
 			var actorId = actorIds[i];
 
 			if (data && data.key && data.clusterId) {
-				addresses.push({
+				addresses[actorId] = {
 					actorId: actorId,
 					clusterId: data.clusterId,
 					addrName: 'sess/' + actorId + ':' + data.key,
 					language: data.language
-				});
+				};
 			}
 		}
 

--- a/lib/state/Readme.md
+++ b/lib/state/Readme.md
@@ -31,14 +31,6 @@ Will register the actorId and session. This is called from the constructor if a 
 
 **Please note: you probably do not want to bind the state object to a session.**
 
-### state.setTimeout(number msec)
-
-If the state object is not closed within the given time, it will automatically close itself.
-
-### state.clearTimeout()
-
-If a timeout has been set, this will remove it.
-
 ### boolean state.canAccess(string accessLevel)
 
 Returns `true` if the registered session is authorised at the given access level. Returns `false` otherwise.

--- a/lib/state/state.js
+++ b/lib/state/state.js
@@ -63,8 +63,8 @@ function State(actorId, session) {
 	this.myEvents = [];           // array of JSON serialized events for this session
 
 	this.addresses = {};            // { actorId: { actorId, language, addrName, clusterId }, actorId: false }
-	this.otherEvents = undefined;	// events for other actors: { actorId: [ list of events ], actorId: etc... }
-	this.broadcastEvents = undefined;
+	this.otherEvents = {};	// events for other actors: { actorId: [ list of events ], actorId: etc... }
+	this.broadcastEvents = [];
 
 	this.timeout = null;	// timeout
 	exports.emit('created');
@@ -111,7 +111,7 @@ State.prototype.registerSession = function (session) {
 
 	// in development mode, a user can access everything
 	if (mage.isDevelopmentMode('adminEverywhere') && this.acl.indexOf('*') === -1) {
-		this.acl.push('*');
+		this.acl.unshift('*');
 	}
 };
 
@@ -131,6 +131,11 @@ State.prototype.unregisterSession = function () {
  * @returns {boolean}
  */
 State.prototype.canAccess = function (acl) {
+	// user with wildcard can access everything
+	if (this.acl.indexOf('*') !== -1) {
+		return true;
+	}
+
 	// exports.acl was probably forgotten on a user command
 	if (!acl) {
 		logger.error(new Error('No ACL provided'));
@@ -150,11 +155,6 @@ State.prototype.canAccess = function (acl) {
 
 	// wildcard-access means access for everyone
 	if (acl.indexOf('*') !== -1) {
-		return true;
-	}
-
-	// user with wildcard can access everything
-	if (this.acl.indexOf('*') !== -1) {
 		return true;
 	}
 
@@ -185,9 +185,14 @@ State.prototype.getDescription = function () {
  * @summary Mark state as closing, and internally save a copy of the stack trace at this point.
  */
 State.prototype.setClosingCallStack = function () {
-	if (!this._closingCallStack) {
-		this._closingCallStack = new Error().stack;
+	if (this._closingCallStack) {
+		throw new StateAccessError('State is already marked as closing', {
+			description: this.description,
+			stack: this._closingCallStack
+		});
 	}
+
+	this._closingCallStack = new Error().stack;
 };
 
 /**
@@ -292,7 +297,17 @@ State.prototype.findActors = function (actorIds, cb) {
 };
 
 
-State.prototype.emitEvents = function (cb) {
+function parseEvents(isError, events) {
+	if (!events) {
+		return [];
+	}
+
+	return events
+		.filter((entry) => !isError || entry.alwaysEmit)
+		.map((entry) => entry.evt);
+}
+
+State.prototype.emitEvents = function (isErrorState, cb) {
 	if (!mage.core.msgServer) {
 		logger.warning('Cannot emit events without msgServer set up.');
 		return cb();
@@ -302,20 +317,19 @@ State.prototype.emitEvents = function (cb) {
 
 	// this function emits all events to players who are not state.actorId
 
-	events = this.broadcastEvents;
+	events = parseEvents(isErrorState, this.broadcastEvents);
+	this.broadcastEvents = [];
 
-	if (events) {
-		this.broadcastEvents = undefined;
+	if (events.length > 0) {
 		mage.core.msgServer.broadcast('[' + events.join(',') + ']');
 	}
 
 	events = this.otherEvents;
+	this.otherEvents = {};
 
-	if (!events) {
+	if (events.length === 0) {
 		return cb();
 	}
-
-	this.otherEvents = undefined;
 
 	var actorIds = Object.keys(events);
 
@@ -330,35 +344,18 @@ State.prototype.emitEvents = function (cb) {
 
 		for (var i = 0; i < actorIds.length; i += 1) {
 			var actorId = actorIds[i];
-			var entries = events[actorId];
+			var entries = parseEvents(isErrorState, events[actorId]);
 			var address = addresses[actorId];
 
-			if (!entries || !address) {
+			if (entries.length === 0 || !address) {
 				continue;
 			}
 
-			var actorEvents = [];	// what we'll be emitting
-
-			for (var j = 0; j < entries.length; j += 1) {
-				var entry = entries[j];
-
-				if (!entry.language || entry.language === address.language) {
-					actorEvents.push(entry.evt);
-				}
-			}
-
-			if (actorEvents.length > 0) {
-				mage.core.msgServer.send(address.addrName, address.clusterId, '[' + actorEvents.join(',') + ']');
-			}
+			mage.core.msgServer.send(address.addrName, address.clusterId, '[' + entries.join(',') + ']');
 		}
 
 		return cb();
 	});
-};
-
-
-State.prototype.language = function (fallback) {
-	return this.session ? this.session.language : (fallback || 'en');
 };
 
 
@@ -375,14 +372,13 @@ function serializeEvent(path, data, isJson) {
 }
 
 
-State.prototype.broadcast = function (path, data, isJson) {
-	var evt = serializeEvent(path, data, isJson);
+State.prototype.broadcast = function (path, data, options) {
+	options = options || {};
 
-	if (this.broadcastEvents) {
-		this.broadcastEvents.push(evt);
-	} else {
-		this.broadcastEvents = [evt];
-	}
+	var evt = serializeEvent(path, data, options.isJson);
+	var entry = { evt: evt, alwaysEmit: options.alwaysEmit };
+
+	this.broadcastEvents.push(entry);
 };
 
 
@@ -399,31 +395,29 @@ function isSelf(state, actorId) {
 }
 
 
-State.prototype.emit = function (actorIds, path, data, language, isJson) {
-	// language may be omitted
-	// if language is provided, it will only emit if the language matches the language used by actorId
-
-	var len;
-
-	if (Array.isArray(actorIds)) {
-		len = actorIds.length;
-	} else {
+State.prototype.emit = function (actorIds, path, data, options) {
+	if (!Array.isArray(actorIds)) {
 		actorIds = [actorIds];
-		len = 1;
 	}
+
+	options = options || {};
+
+	const len = actorIds.length;
 
 	if (len === 0) {
 		return;
 	}
 
-	var evt = serializeEvent(path, data, isJson);
+	var evt = serializeEvent(path, data, options.isJson);
+	var entry = { evt: evt, alwaysEmit: options.alwaysEmit };
+
 	var sent = {};          // { actorId: true, actorId: true, ... }
 	var sentToSelf = false; // indicates whether the event has been sent to the user themselves
 
 	for (var i = 0; i < len; i++) {
 		if (isSelf(this, actorIds[i])) {
 			if (!sentToSelf) {
-				this.myEvents.push(evt);
+				this.myEvents.push(entry);
 			}
 			sentToSelf = true;
 			continue;
@@ -439,75 +433,46 @@ State.prototype.emit = function (actorIds, path, data, language, isJson) {
 
 		sent[actorId] = true;
 
-		// language matches will be sorted out when we really emit them
-
-		var entry = { evt: evt, language: language };
-
-		if (!this.otherEvents) {
-			this.otherEvents = {};
-			this.otherEvents[actorId] = [entry];
-		} else {
-			if (!this.otherEvents[actorId]) {
-				this.otherEvents[actorId] = [entry];
-			} else {
-				this.otherEvents[actorId].push(entry);
-			}
+		if (!this.otherEvents[actorId]) {
+			this.otherEvents[actorId] = [];
 		}
+
+		this.otherEvents[actorId].push(entry);
 	}
 };
 
-// deprecated
-State.prototype.emitToActors = State.prototype.emit;
 
-
-State.prototype.error = function (code, logDetails, cb) {
+State.prototype.error = function (code, logMessage, cb) {
 	exports.emit('stateError');
 
-	if (code === null || code === undefined) {
-		code = 'server';
-	}
-
-	if (code.code || code.message) {
-		// probably an error object, so turn it into a string
+	// Extract the error code or message
+	if (code instanceof Error) {
 		code = code.code || code.message;
 	}
 
-	if (typeof code === 'object' || Array.isArray(code)) {
+	// Invalid codes are logged, but a different value is set to be returned
+	if (!code || typeof code === 'object') {
 		logger.error('Invalid state error code:', code, '(falling back to "server")');
 		code = 'server';
 	}
 
+	// Code must be a string
 	code = '' + code;
 
-	var channel, args = [];
-
-	var prefix = [];
-
-	if (this.actorId) {
-		prefix.push('Actor ' + this.actorId);
-	}
-
-	if (this.description) {
-		prefix.push(this.description);
-	}
-
-	if (prefix.length > 0) {
-		args.push('(' + prefix.join(', ') + ')');
-	}
-
-	if (logDetails) {
-		channel = 'error';
-		args.push(logDetails);
-	} else {
-		channel = 'debug';
-		args.push('(error code: ' + JSON.stringify(code) + ')');
-	}
-
-	logger[channel].apply(logger, args);
-
+	// Return error code is set on the state
 	this.errorCode = JSON.stringify(code);
 
-	if (cb && typeof cb === 'function') {
+	// Log the result
+	if (logMessage) {
+		logger.error
+			.data({
+				actorId: this.actorId,
+				description: this.description
+			})
+			.log(logMessage);
+	}
+
+	if (cb) {
 		cb(code);
 	}
 };
@@ -517,36 +482,62 @@ State.prototype.respond = function (response, isJson) {
 	this.response = isJson ? response : JSON.stringify(response);
 };
 
+/**
+ * Distribute all events currently stacked on
+ * this state object.
+ *
+ * If you wish to also distribute archivist mutations stacked
+ * on this state, please have a look at the `distribute` method
+ * instead.
+ *
+ * @param {Function} cb callback function
+ */
+State.prototype.distributeEvents = function (cb) {
+	this.otherEvents[this.actorId] = this.myEvents.slice();
+	this.myEvents.length = 0;
 
-function closeWithError(state, cb) {
-	cb(null, {
-		errorCode: state.errorCode,
-		myEvents: state.myEvents.length ? state.myEvents : undefined
-	});
-}
+	this.emitEvents(false, cb);
+};
 
-
-function closeWithSuccess(state, cb) {
-	state.archivist.distribute(function (error) {
-		// archivist errors can only come from the operations before writing anything to a vault,
-		// (beforeDistribute hooks, operation validation, etc), so it is still safe to bail out and
-		// report an error.
-
+/**
+ * Distribute both events and archivist operations
+ * currently stacked on this state object.
+ *
+ * @param {Function} cb callback function
+ */
+State.prototype.distribute = function (cb) {
+	this.archivist.distribute((error) => {
 		if (error) {
-			return closeWithError(state, cb);
+			return cb(error);
 		}
 
-		state.emitEvents(function () {
-			// create a response and return it to cb
-
-			cb(null, {
-				response: state.response,
-				myEvents: state.myEvents.length ? state.myEvents : undefined
-			});
-		});
+		this.distributeEvents(cb);
 	});
+};
+
+
+function respond(isErrorState, state, cb) {
+	// extract response events
+	const myEvents = parseEvents(isErrorState, state.myEvents);
+
+	// create response data
+	const response = {
+		response: state.response,
+		myEvents: myEvents.length ? myEvents : undefined
+	};
+
+	// cleanup
+	state.destroy();
+
+	// return the response
+	if (cb) {
+		cb(null, response);
+	}
 }
 
+function close(isErrorState, state, cb) {
+	state.emitEvents(isErrorState, () => respond(isErrorState, state, cb));
+}
 
 State.prototype.close = function (cb) {
 	if (this.timeout) {
@@ -564,28 +555,13 @@ State.prototype.close = function (cb) {
 
 	logger.verbose('Closing state:', this.getDescription());
 
-	var fn;
-	var that = this;
-
+	// Close without distributing, discard changes
 	if (this.errorCode) {
-		fn = closeWithError;
-	} else {
-		fn = closeWithSuccess;
+		return close(true, this, cb);
 	}
 
-	// do the rollback or commit
-
-	fn.call(null, this, function (error, response) {
-		// cleanup
-
-		that.destroy();
-
-		// return the response
-
-		if (cb) {
-			cb(null, response);
-		}
-	});
+	// Commit changes before closing
+	return this.archivist.distribute((error) => close(!!error, this, cb));
 };
 
 function destroyProperty(state, name) {

--- a/lib/state/state.js
+++ b/lib/state/state.js
@@ -55,7 +55,7 @@ function lookupAddresses(state, actorIds, cb) {
 		return !address || now - address.time >= state.cacheTimeout;
 	});
 
-	mage.session.getActorAddresses(this, lookup, function (error, addresses) {
+	mage.session.getActorAddresses(state, lookup, function (error, addresses) {
 		if (error) {
 			return cb(error);
 		}

--- a/lib/state/state.js
+++ b/lib/state/state.js
@@ -7,8 +7,17 @@ var mage;
 var logger;
 var Archivist;
 
+/**
+ * Default description if none is set on a state object
+ */
 var NO_DESCRIPTION = 'no description';
 
+/**
+ * State error class
+ *
+ * @param {*} message
+ * @param {*} details
+ */
 function StateAccessError(message, details) {
 	Error.captureStackTrace(this, this.constructor);
 	Object.assign(this, details);
@@ -20,13 +29,65 @@ function StateAccessError(message, details) {
 util.inherits(StateAccessError, Error);
 
 /**
+ * Utility method to lookup and cache addresses
+ * to send messages to given actorIds
+ *
+ * @param {*} state
+ * @param {*} actorIds
+ * @param {*} cb
+ */
+function lookupAddresses(state, actorIds, cb) {
+	if (!mage.session) {
+		return cb(new Error('Cannot find actors without the "session" module set up.'));
+	}
+
+	const now = Date.now();
+
+	// Loook up only the addresses which we are unknown to us,
+	// or the ones which are no longer valid
+	var lookup = actorIds.filter((actorId) => {
+		const address = state.addressesCache[actorId];
+
+		return !address || now - address.time >= state.cacheTimeout;
+	});
+
+	mage.session.getActorAddresses(this, lookup, function (error, addresses) {
+		if (error) {
+			return cb(error);
+		}
+
+		for (let i = 0; i < addresses.length; i += 1) {
+			const address = addresses[i];
+			const actorId = address.actorId;
+
+			state.addressesCache[actorId] = Object.assign(address, {
+				exists: true,
+				time: now
+			});
+		}
+
+		for (let i = 0; i < lookup.length; i += 1) {
+			const actorId = lookup[i];
+
+			if (state.addressesCache[actorId] === undefined) {
+				state.addressesCache[actorId] = {
+					exists: false,
+					time: now
+				};
+			}
+		}
+
+		return cb(null, state.addressesCache);
+	});
+};
+
+/**
  * To allow flexibility for testing, some objects are passed in with initialize.
  *
  * @param {Object}   mageInstance           A mage instance.
  * @param {Object}   mageLogger             A mage logger.
  * @param {Function} archivistConstructor   The archivist constructor.
  */
-
 exports.initialize = function (mageInstance, mageLogger, archivistConstructor) {
 	mage = mageInstance;
 	logger = mageLogger;
@@ -34,39 +95,78 @@ exports.initialize = function (mageInstance, mageLogger, archivistConstructor) {
 };
 
 
-function State(actorId, session) {
-	// behaves like a transaction, and will send off everything that happened after commit() is called.
+/**
+ * Extract values from an option object and apply them
+ * to a state (or use a default value otherwise)
+ *
+ * @param {*} state
+ * @param {*} opts
+ * @param {*} key
+ * @param {*} defaultValue
+ */
+function setFromOpts(state, opts, key, defaultValue) {
+	var optsVal = opts[key];
 
+	if (optsVal) {
+		state[key] = optsVal;
+	} else {
+		state[key] = defaultValue;
+	}
+}
+
+/**
+ * State class
+ *
+ * The state library exposes a constructor that constructs objects which form an interface
+ * between an actor, a session and the archivist. Virtually any command that involves reading
+ * and modification of data should be managed by a state object.
+ *
+ * When you’re done using the state class, always make sure to clean it up by calling close() on it.
+ * MAGE’s module and command center systems that bridge the communication between client
+ * and server use the State object for API responses and server-sent events.
+ *
+ * @param {*} actorId
+ * @param {*} session
+ * @param {*} opts
+ */
+function State(actorId, session, opts = {}) {
 	this.actorId = actorId ? ('' + actorId) : undefined;
-	this.session = undefined;
 	this.acl = [];
 
-	// use registerSession
-
-	if (session) {
-		this.registerSession(session);
-	}
-
-	// available in user commands, gives you the name of the appName where the command is running
-
-	this.appName = undefined;
-
-	this.data = {};   // may be used to pass data around between functions
-	this.description = null;
-
-	this.archivist = new Archivist(this);
-
-	// information for command response output:
-
+	// Information for command response output:
 	this.errorCode = undefined;   // JSON serialized error code to a user command
 	this.response = undefined;    // JSON serialized response to a user command
 	this.myEvents = [];           // array of JSON serialized events for this session
 
-	this.addresses = {};            // { actorId: { actorId, language, addrName, clusterId }, actorId: false }
+	this.addressesCache = {};            // { actorId: { actorId, language, addrName, clusterId }, actorId: false }
 	this.otherEvents = {};	// events for other actors: { actorId: [ list of events ], actorId: etc... }
 	this.broadcastEvents = [];
 
-	this.timeout = null;	// timeout
+	// Available in user commands, gives you the name of the appName where the command is running
+	setFromOpts(this, opts, 'appName', undefined);
+	setFromOpts(this, opts, 'description', undefined);
+	setFromOpts(this, opts, 'cacheTimeout', 500);
+
+	// This is used to carry data around through the execution path
+	setFromOpts(this, opts, 'data', {});
+
+	// Register session
+	this.session = null;
+
+	if (session) {
+		this.registerSession(session);
+	};
+
+	// Setup archivist
+	this.archivist = new Archivist(this);
+
+	// Set a timeout
+	this.timeout = null;
+
+	if (opts.timeout) {
+		this.setTimeout(opts.timeout);
+	}
+
 	exports.emit('created');
 }
 
@@ -74,14 +174,23 @@ function State(actorId, session) {
 exports.State = State;
 
 
+/**
+ * Define a timeout on the state
+ *
+ * Once the timeout is reached, the state will automatically
+ * report an error to the end-user.
+ *
+ * Note that you do not have to call `clearTimeout` manually when
+ * receiving a state in a user command; this will be done automatically for you.
+ *
+ * @param {number} timeout
+ */
 State.prototype.setTimeout = function (timeout) {
 	this.clearTimeout();
 
-	var that = this;
-
-	this.timeout = setTimeout(function () {
-		that.error(null, 'State timed out: ' + that.getDescription(), function () {
-			that.close();
+	this.timeout = setTimeout(() => {
+		this.error('timeout', 'State timed out: ' + this.getDescription(), () => {
+			this.close();
 		});
 
 		exports.emit('timeOut', timeout);
@@ -89,6 +198,14 @@ State.prototype.setTimeout = function (timeout) {
 };
 
 
+/**
+ * Clear a given state's timeout
+ *
+ *
+ * This will do nothing if a timeout is not set on the state
+ *
+ * @memberOf State
+ */
 State.prototype.clearTimeout = function () {
 	if (this.timeout) {
 		clearTimeout(this.timeout);
@@ -172,31 +289,41 @@ State.prototype.canAccess = function (acl) {
 };
 
 
+/**
+ * Set the description for this state
+ *
+ * Used mostly by command center to mark a state as
+ * originating from a given user command.
+ */
 State.prototype.setDescription = function (description) {
 	this.description = description;
 };
 
 
+/**
+ * Get the description for this state
+ */
 State.prototype.getDescription = function () {
 	return this.description || NO_DESCRIPTION;
 };
 
+
 /**
- * @summary Mark state as closing, and internally save a copy of the stack trace at this point.
+ * Mark state as closing, and internally save a copy of the stack trace at this point.
  */
 State.prototype.setClosingCallStack = function () {
 	if (this._closingCallStack) {
 		throw new StateAccessError('State is already marked as closing', {
-			description: this.description,
-			stack: this._closingCallStack
+			originallyClosedAt: this.getClosingDetails()
 		});
 	}
 
 	this._closingCallStack = new Error().stack;
 };
 
+
 /**
- * @summary Retrieve a copy of the stack trace of when the state was set as closing.
+ * Retrieve a copy of the stack trace of when the state was set as closing.
  */
 State.prototype.getClosingCallStack = function () {
 	if (!this._closingCallStack) {
@@ -208,21 +335,20 @@ State.prototype.getClosingCallStack = function () {
 	});
 };
 
+
 /**
- * @summary Mark state as closing
+ * Mark state as closing
  */
 State.prototype.setClosing = function () {
 	this.closing = true;
 	this.setClosingCallStack();
 };
 
-/**
- * @summary Check if the state has been marked as closing.
- */
-State.prototype.isClosing = function () {
-	return !!this.closing || !!this._closingCallStack;
-};
 
+/**
+ * Retrieve details about where a given state was originally
+ * closed
+ */
 State.prototype.getClosingDetails = function () {
 	return {
 		description: this.getDescription(),
@@ -230,52 +356,11 @@ State.prototype.getClosingDetails = function () {
 	};
 };
 
-State.prototype.lookupAddresses = function (actorIds, cb) {
-	if (!mage.session) {
-		logger.warning('Cannot find actors without the "session" module set up.');
-		return cb();
-	}
-
-	var lookup = [];
-	for (var i = 0; i < actorIds.length; i += 1) {
-		var actorId = actorIds[i];
-
-		if (this.addresses[actorId] === undefined) {
-			lookup.push(actorId);
-		}
-	}
-
-	var that = this;
-
-	mage.session.getActorAddresses(this, lookup, function (error, addresses) {
-		if (error) {
-			return cb(error);
-		}
-
-		var actorId, i;
-
-		for (i = 0; i < addresses.length; i += 1) {
-			var address = addresses[i];
-			actorId = address.actorId;
-
-			that.addresses[actorId] = address;
-		}
-
-		for (i = 0; i < lookup.length; i += 1) {
-			actorId = lookup[i];
-
-			if (that.addresses[actorId] === undefined) {
-				that.addresses[actorId] = false;
-			}
-		}
-
-		return cb(null, that.addresses);
-	});
-};
-
-
+/**
+ * Parse a list of actorIds, and verify who is online
+ */
 State.prototype.findActors = function (actorIds, cb) {
-	this.lookupAddresses(actorIds, function (error, addresses) {
+	lookupAddresses(this, actorIds, function (error, addresses) {
 		if (error) {
 			return cb(error);
 		}
@@ -285,7 +370,7 @@ State.prototype.findActors = function (actorIds, cb) {
 		for (var i = 0; i < actorIds.length; i += 1) {
 			var actorId = actorIds[i];
 
-			if (addresses[actorId]) {
+			if (addresses[actorId].exists) {
 				found.online.push(actorId);
 			} else {
 				found.offline.push(actorId);
@@ -298,19 +383,15 @@ State.prototype.findActors = function (actorIds, cb) {
 
 
 function parseEvents(isError, events) {
-	if (!events) {
-		return [];
-	}
-
 	return events
 		.filter((entry) => !isError || entry.alwaysEmit)
 		.map((entry) => entry.evt);
 }
 
+
 State.prototype.emitEvents = function (isErrorState, cb) {
 	if (!mage.core.msgServer) {
-		logger.warning('Cannot emit events without msgServer set up.');
-		return cb();
+		return cb(new Error('Cannot emit events without msgServer set up.'));
 	}
 
 	var events;
@@ -327,17 +408,13 @@ State.prototype.emitEvents = function (isErrorState, cb) {
 	events = this.otherEvents;
 	this.otherEvents = {};
 
-	if (events.length === 0) {
-		return cb();
-	}
-
 	var actorIds = Object.keys(events);
 
 	if (actorIds.length === 0) {
 		return cb();
 	}
 
-	this.lookupAddresses(actorIds, function (error, addresses) {
+	lookupAddresses(this, actorIds, function (error, addresses) {
 		if (error) {
 			return cb(error);
 		}
@@ -347,7 +424,7 @@ State.prototype.emitEvents = function (isErrorState, cb) {
 			var entries = parseEvents(isErrorState, events[actorId]);
 			var address = addresses[actorId];
 
-			if (entries.length === 0 || !address) {
+			if (entries.length === 0 || address.exists === false) {
 				continue;
 			}
 
@@ -396,6 +473,10 @@ function isSelf(state, actorId) {
 
 
 State.prototype.emit = function (actorIds, path, data, options) {
+	if (!path) {
+		throw new Error('Missing path or event name');
+	}
+
 	if (!Array.isArray(actorIds)) {
 		actorIds = [actorIds];
 	}
@@ -411,27 +492,14 @@ State.prototype.emit = function (actorIds, path, data, options) {
 	var evt = serializeEvent(path, data, options.isJson);
 	var entry = { evt: evt, alwaysEmit: options.alwaysEmit };
 
-	var sent = {};          // { actorId: true, actorId: true, ... }
-	var sentToSelf = false; // indicates whether the event has been sent to the user themselves
-
 	for (var i = 0; i < len; i++) {
 		if (isSelf(this, actorIds[i])) {
-			if (!sentToSelf) {
-				this.myEvents.push(entry);
-			}
-			sentToSelf = true;
+			this.myEvents.push(entry);
 			continue;
 		}
 
 		// cast actorId to string
 		var actorId = String(actorIds[i]);
-
-		// avoid duplicates
-		if (sent[actorId]) {
-			continue;
-		}
-
-		sent[actorId] = true;
 
 		if (!this.otherEvents[actorId]) {
 			this.otherEvents[actorId] = [];
@@ -482,6 +550,7 @@ State.prototype.respond = function (response, isJson) {
 	this.response = isJson ? response : JSON.stringify(response);
 };
 
+
 /**
  * Distribute all events currently stacked on
  * this state object.
@@ -493,8 +562,10 @@ State.prototype.respond = function (response, isJson) {
  * @param {Function} cb callback function
  */
 State.prototype.distributeEvents = function (cb) {
-	this.otherEvents[this.actorId] = this.myEvents.slice();
-	this.myEvents.length = 0;
+	if (this.actorId) {
+		this.otherEvents[this.actorId] = this.myEvents.slice();
+		this.myEvents.length = 0;
+	}
 
 	this.emitEvents(false, cb);
 };
@@ -536,21 +607,12 @@ function respond(isErrorState, state, cb) {
 }
 
 function close(isErrorState, state, cb) {
+	// Todo: what if state.emitEvents returns an error?
 	state.emitEvents(isErrorState, () => respond(isErrorState, state, cb));
 }
 
 State.prototype.close = function (cb) {
-	if (this.timeout) {
-		this.clearTimeout();
-		this.timeout = null;
-	}
-
-	if (this.isClosing()) {
-		throw new StateAccessError('Tried to close an already closing state', {
-			originallyClosedAt: this.getClosingDetails()
-		});
-	}
-
+	this.clearTimeout();
 	this.setClosing();
 
 	logger.verbose('Closing state:', this.getDescription());

--- a/lib/state/state.js
+++ b/lib/state/state.js
@@ -45,44 +45,7 @@ function lookupAddresses(state, actorIds, cb) {
 		}));
 	}
 
-	const now = Date.now();
-
-	// Loook up only the addresses which we are unknown to us,
-	// or the ones which are no longer valid
-	var lookup = actorIds.filter((actorId) => {
-		const address = state.addressesCache[actorId];
-
-		return !address || now - address.time >= state.cacheTimeout;
-	});
-
-	mage.session.getActorAddresses(state, lookup, function (error, addresses) {
-		if (error) {
-			return cb(error);
-		}
-
-		for (let i = 0; i < addresses.length; i += 1) {
-			const address = addresses[i];
-			const actorId = address.actorId;
-
-			state.addressesCache[actorId] = Object.assign(address, {
-				exists: true,
-				time: now
-			});
-		}
-
-		for (let i = 0; i < lookup.length; i += 1) {
-			const actorId = lookup[i];
-
-			if (state.addressesCache[actorId] === undefined) {
-				state.addressesCache[actorId] = {
-					exists: false,
-					time: now
-				};
-			}
-		}
-
-		return cb(null, state.addressesCache);
-	});
+	mage.session.getActorAddresses(state, actorIds, cb);
 };
 
 /**
@@ -329,7 +292,7 @@ State.prototype.findActors = function (actorIds, cb) {
 		for (var i = 0; i < actorIds.length; i += 1) {
 			var actorId = actorIds[i];
 
-			if (addresses[actorId].exists) {
+			if (addresses[actorId]) {
 				found.online.push(actorId);
 			} else {
 				found.offline.push(actorId);
@@ -399,7 +362,7 @@ State.prototype.emitEvents = function (isErrorState, cb) {
 			var entries = parseEvents(isErrorState, events[actorId]);
 			var address = addresses[actorId];
 
-			if (entries.length === 0 || address.exists === false) {
+			if (entries.length === 0 || !address) {
 				continue;
 			}
 

--- a/lib/state/state.js
+++ b/lib/state/state.js
@@ -133,7 +133,9 @@ function setFromOpts(state, opts, key, defaultValue) {
  * @param {*} session
  * @param {*} opts
  */
-function State(actorId, session, opts = {}) {
+function State(actorId, session, opts) {
+	opts = opts || {};
+
 	this.actorId = actorId ? ('' + actorId) : undefined;
 	this.acl = [];
 

--- a/lib/state/state.js
+++ b/lib/state/state.js
@@ -160,58 +160,11 @@ function State(actorId, session, opts = {}) {
 	// Setup archivist
 	this.archivist = new Archivist(this);
 
-	// Set a timeout
-	this.timeout = null;
-
-	if (opts.timeout) {
-		this.setTimeout(opts.timeout);
-	}
-
 	exports.emit('created');
 }
 
 
 exports.State = State;
-
-
-/**
- * Define a timeout on the state
- *
- * Once the timeout is reached, the state will automatically
- * report an error to the end-user.
- *
- * Note that you do not have to call `clearTimeout` manually when
- * receiving a state in a user command; this will be done automatically for you.
- *
- * @param {number} timeout
- */
-State.prototype.setTimeout = function (timeout) {
-	this.clearTimeout();
-
-	this.timeout = setTimeout(() => {
-		this.error('timeout', 'State timed out: ' + this.getDescription(), () => {
-			this.close();
-		});
-
-		exports.emit('timeOut', timeout);
-	}, timeout);
-};
-
-
-/**
- * Clear a given state's timeout
- *
- *
- * This will do nothing if a timeout is not set on the state
- *
- * @memberOf State
- */
-State.prototype.clearTimeout = function () {
-	if (this.timeout) {
-		clearTimeout(this.timeout);
-		this.timeout = null;
-	}
-};
 
 /**
  * Register a session on this state, also updates the access level for that state
@@ -612,7 +565,6 @@ function close(isErrorState, state, cb) {
 }
 
 State.prototype.close = function (cb) {
-	this.clearTimeout();
 	this.setClosing();
 
 	logger.verbose('Closing state:', this.getDescription());

--- a/lib/state/state.js
+++ b/lib/state/state.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 
@@ -18,15 +20,15 @@ var NO_DESCRIPTION = 'no description';
  * @param {*} message
  * @param {*} details
  */
-function StateAccessError(message, details) {
+function StateError(message, details) {
 	Error.captureStackTrace(this, this.constructor);
 	Object.assign(this, details);
 
 	this.message = message;
-	this.name = 'StateAccessError';
+	this.name = 'StateError';
 };
 
-util.inherits(StateAccessError, Error);
+util.inherits(StateError, Error);
 
 /**
  * Utility method to lookup and cache addresses
@@ -38,7 +40,9 @@ util.inherits(StateAccessError, Error);
  */
 function lookupAddresses(state, actorIds, cb) {
 	if (!mage.session) {
-		return cb(new Error('Cannot find actors without the "session" module set up.'));
+		return cb(new StateError('Cannot find actors without the "session" module set up.', {
+			actorIds: actorIds
+		}));
 	}
 
 	const now = Date.now();
@@ -266,7 +270,7 @@ State.prototype.getDescription = function () {
  */
 State.prototype.setClosingCallStack = function () {
 	if (this._closingCallStack) {
-		throw new StateAccessError('State is already marked as closing', {
+		throw new StateError('State is already marked as closing', {
 			originallyClosedAt: this.getClosingDetails()
 		});
 	}
@@ -280,7 +284,7 @@ State.prototype.setClosingCallStack = function () {
  */
 State.prototype.getClosingCallStack = function () {
 	if (!this._closingCallStack) {
-		throw new StateAccessError('Attempted to access closing call stack but call stack is not set');
+		throw new StateError('Attempted to access closing call stack but call stack is not set');
 	}
 
 	return this._closingCallStack.split('\n').map(function (line) {
@@ -343,26 +347,42 @@ function parseEvents(isError, events) {
 
 
 State.prototype.emitEvents = function (isErrorState, cb) {
-	if (!mage.core.msgServer) {
-		return cb(new Error('Cannot emit events without msgServer set up.'));
-	}
-
-	var events;
-
-	// this function emits all events to players who are not state.actorId
-
-	events = parseEvents(isErrorState, this.broadcastEvents);
-	this.broadcastEvents = [];
-
-	if (events.length > 0) {
-		mage.core.msgServer.broadcast('[' + events.join(',') + ']');
-	}
-
-	events = this.otherEvents;
+	// Reset the state's events store
+	const events = this.otherEvents;
 	this.otherEvents = {};
 
-	var actorIds = Object.keys(events);
+	const broadcastEvents = this.broadcastEvents;
+	this.broadcastEvents = [];
 
+	// Extract the list of actorIds we will be sending messages
+	// to directly (not by broadcast)
+	const actorIds = Object.keys(events);
+
+	// If we have nothing to do at all, return immediately
+	if (actorIds.length === 0 && broadcastEvents.length === 0) {
+		return cb();
+	}
+
+	// We either have messages to broadcast, or messages to send
+	// to a number of actorIds; confirm that msgServer is present,
+	// or else return an error
+	if (!mage.core.msgServer) {
+		return cb(new StateError('Cannot emit events without msgServer set up.', {
+			events: events,
+			broadcastEvents: broadcastEvents
+		}));
+	}
+
+	// Send all broadcast events
+	const parsedBroadcastEvents = parseEvents(isErrorState, broadcastEvents);
+
+	if (parsedBroadcastEvents.length > 0) {
+		mage.core.msgServer.broadcast('[' + parsedBroadcastEvents.join(',') + ']');
+	}
+
+	// If we have no other messages to send,
+	// return early; this is to avoid running
+	// additional code that would only delay the return
 	if (actorIds.length === 0) {
 		return cb();
 	}
@@ -560,8 +580,19 @@ function respond(isErrorState, state, cb) {
 }
 
 function close(isErrorState, state, cb) {
-	// Todo: what if state.emitEvents returns an error?
-	state.emitEvents(isErrorState, () => respond(isErrorState, state, cb));
+	state.emitEvents(isErrorState, (error) => {
+		if (error) {
+			logger.error
+				.data(error)
+				.data(state.getClosingDetails())
+				.details('Events are emitted on a best effort basis; in the case of this error')
+				.details('showing up during the execution of a user command, this means that')
+				.details('user command may still return successfully, but events won\'t be emitted')
+				.log('Failed to emit events to users', error);
+		}
+
+		respond(isErrorState, state, cb);
+	});
 }
 
 State.prototype.close = function (cb) {
@@ -575,19 +606,23 @@ State.prototype.close = function (cb) {
 	}
 
 	// Commit changes before closing
+	// Note: archivist.distribute is expected to be calling
+	// `state.error` on its own should an error be returned;
+	// therefore, all we should need to care about is whether we
+	// are in an error state upon return
 	return this.archivist.distribute((error) => close(!!error, this, cb));
 };
 
 function destroyProperty(state, name) {
 	Object.defineProperty(state, name, {
 		get: function () {
-			throw new StateAccessError('Tried to access attribute on a closing state', {
+			throw new StateError('Tried to access attribute on a closing state', {
 				property: name,
 				originallyClosedAt: state.getClosingDetails()
 			});
 		},
 		set: function () {
-			throw new StateAccessError('Tried to set attribute on a closing state', {
+			throw new StateError('Tried to set attribute on a closing state', {
 				property: name,
 				originallyClosedAt: state.getClosingDetails()
 			});

--- a/lib/state/state.js
+++ b/lib/state/state.js
@@ -360,10 +360,15 @@ State.prototype.emitEvents = function (isErrorState, cb) {
 
 		for (var i = 0; i < actorIds.length; i += 1) {
 			var actorId = actorIds[i];
-			var entries = parseEvents(isErrorState, events[actorId]);
 			var address = addresses[actorId];
 
-			if (entries.length === 0 || !address) {
+			if (!address) {
+				continue;
+			}
+
+			var entries = parseEvents(isErrorState, events[actorId]);
+
+			if (entries.length === 0) {
 				continue;
 			}
 

--- a/lib/state/state.js
+++ b/lib/state/state.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 
 exports = module.exports = new EventEmitter();
@@ -14,21 +13,24 @@ var Archivist;
  */
 var NO_DESCRIPTION = 'no description';
 
-/**
- * State error class
- *
- * @param {*} message
- * @param {*} details
- */
-function StateError(message, details) {
-	Error.captureStackTrace(this, this.constructor);
-	Object.assign(this, details);
 
-	this.message = message;
-	this.name = 'StateError';
-};
+ /**
+  * StateError class
+  */
+class StateError extends Error {
+	/**
+	 * Constructor
+	 *
+	 * @param {string} message
+	 * @param {object} details
+	 */
 
-util.inherits(StateError, Error);
+	constructor(message, details) {
+		super(message);
+		this.name = 'StateError';
+		Object.assign(this, details);
+	}
+}
 
 /**
  * Utility method to lookup and cache addresses
@@ -107,7 +109,6 @@ function State(actorId, session, opts) {
 	this.response = undefined;    // JSON serialized response to a user command
 	this.myEvents = [];           // array of JSON serialized events for this session
 
-	this.addressesCache = {};            // { actorId: { actorId, language, addrName, clusterId }, actorId: false }
 	this.otherEvents = {};	// events for other actors: { actorId: [ list of events ], actorId: etc... }
 	this.broadcastEvents = [];
 
@@ -472,8 +473,8 @@ State.prototype.error = function (code, logMessage, cb) {
 	if (logMessage) {
 		logger.error
 			.data({
-				actorId: this.actorId,
-				description: this.description
+				description: this.description,
+				actorId: this.actorId
 			})
 			.log(logMessage);
 	}
@@ -531,7 +532,13 @@ function respond(isErrorState, state, cb) {
 
 	// create response data
 	const response = {
-		response: state.response,
+		// No response data is sent if we are in an error state
+		response: isErrorState ? undefined : state.response,
+
+		// Return the error code if we are in an error state
+		errorCode: isErrorState ? state.errorCode : undefined,
+
+		// Return all listed events
 		myEvents: myEvents.length ? myEvents : undefined
 	};
 

--- a/mage.ts
+++ b/mage.ts
@@ -2417,7 +2417,7 @@ declare namespace mage {
             findActors(actorIds: string[], callback: (error: Error | null, actors: {
                 online: string[],
                 offline: string[]
-            }) => void);
+            }) => void): void;
 
             /**
              * Send an event to the user

--- a/mage.ts
+++ b/mage.ts
@@ -846,7 +846,7 @@ declare interface IMageCore {
      *
      * @type {{ new(): mage.core.IState }}
      */
-    State: { new(): mage.core.IState };
+    State: { new(actorId?: string, session?: Session, options?: mage.core.IStateOptions): mage.core.IState };
 
 
     /**
@@ -2286,6 +2286,43 @@ declare namespace mage {
             getIp(version: 4 | 6, networks?: string[]): string | null;
         }
 
+        /**
+         * Options you can pass when you manually create a state object
+         */
+        export interface IStateOptions {
+            /**
+             * The name of the application this state was created in
+             */
+            appName?: string;
+
+            /**
+             * A description of what this state is being used for
+             */
+            description?: string;
+
+            /**
+             * Timeout, in milliseconds
+             *
+             * Upon timeout, the state will close automatically.
+             */
+            timeout?: number
+
+            /**
+             * Actor lookup cache timeout
+             *
+             * By default, the lookup cache will be set
+             * to 500 milliseconds.
+             */
+            cacheTimeout?: number
+
+            /**
+             * State metadata
+             *
+             * This data can be used to carry data around through the execution path.
+             */
+            data?: Object
+        }
+
         export interface IState {
             /**
              * Actor ID
@@ -2319,6 +2356,13 @@ declare namespace mage {
              * @memberOf State
              */
             session: Session | null;
+
+            /**
+             * State metadata
+             *
+             * This data can be used to carry data around through the execution path.
+             */
+            data?: Object
 
             /**
              * Reply to the user
@@ -2359,6 +2403,14 @@ declare namespace mage {
             error(code: string | number, error: Error, callback: Function): void;
 
             /**
+             * Parse a list of actorIds, and verify who is online
+             */
+            findActors(actorIds: string[], callback: (error: Error | null, actors: {
+                online: string[],
+                offline: string[]
+            }) => void);
+
+            /**
              * Send an event to the user
              *
              * Note that the event will be blackholed if an user with a given actorId
@@ -2370,7 +2422,7 @@ declare namespace mage {
              *
              * @memberOf State
              */
-            emit<T>(actorId: string | string[], eventName: string | number, data: T, configuration: mage.core.IStateEmitConfig): void;
+            emit<T>(actorId: string | string[], eventName: string | number, data: T, configuration?: mage.core.IStateEmitConfig): void;
 
             /**
              * Broadcast an event to all connected users
@@ -2380,7 +2432,7 @@ declare namespace mage {
              *
              * @memberOf State
              */
-            broadcast<T>(eventName: string | number, data: T, configuration: mage.core.IStateEmitConfig): void;
+            broadcast<T>(eventName: string | number, data: T, configuration?: mage.core.IStateEmitConfig): void;
 
             /**
              * Distribute both events and archivist operations

--- a/mage.ts
+++ b/mage.ts
@@ -2370,7 +2370,7 @@ declare namespace mage {
              *
              * @memberOf State
              */
-            emit<T>(actorId: string | string[], eventName: string | number, data: T): void;
+            emit<T>(actorId: string | string[], eventName: string | number, data: T, configuration: mage.core.IStateEmitConfig): void;
 
             /**
              * Broadcast an event to all connected users
@@ -2380,7 +2380,42 @@ declare namespace mage {
              *
              * @memberOf State
              */
-            broadcast<T>(eventName: string | number, data: T): void;
+            broadcast<T>(eventName: string | number, data: T, configuration: mage.core.IStateEmitConfig): void;
+
+            /**
+             * Distribute both events and archivist operations
+             * currently stacked on this state object.
+             *
+             * @memberOf State
+             */
+            distribute(callback: (error?: Error) => void): void;
+
+            /**
+             * Distribute all events currently stacked on
+             * this state object.
+             *
+             * If you wish to also distribute archivist mutations stacked
+             * on this state, please have a look at the `distribute` method
+             * instead.
+             *
+             * @memberOf State
+             */
+            distributeEvents(callback: (error?: Error) => void): void;
+
+            /**
+             * Close this state object
+             *
+             * **Note**: You should never really have to use this method, it is
+             * only documented for informational purposes.
+             *
+             * This will trigger the same thing as `distribute`, but will
+             * return the response value set on the state and the
+             * events to be returned directly to the actor this state refers
+             * to.
+             *
+             * @memberOf State
+             */
+            close(callback: (error: Error | null, data: { response: any, events: any }) => void): void;
 
             /**
              * Register a session on the user
@@ -2433,6 +2468,30 @@ declare namespace mage {
              * @memberOf State
              */
             clearTimeout(): void;
+        }
+
+        /**
+         * State emit/broadcast optional configuration
+         */
+        export interface IStateEmitConfig {
+
+            /**
+             * Set if the data to emit has already been stringified
+             *
+             * In some cases, you might want to emit data that has already been
+             * serialized to a JSON string; to do so, set this option to true.
+             */
+            isJson?: boolean;
+
+            /**
+             * Always emit, even on error
+             *
+             * By default, events will only be emitted if the related call
+             * is successful; however, you might want to make sure an event
+             * will always be emitted, even on error. Set this configuration
+             * entry to `true` to make sure the event will always be emitted.
+             */
+            alwaysEmit?: boolean;
         }
     }
 }

--- a/mage.ts
+++ b/mage.ts
@@ -158,7 +158,9 @@ declare class Archivist {
     del(topicName: string, index: mage.archivist.IArchivistIndex): void;
 
     /**
+     * Touch a topic
      *
+     * Used to reset the expiration timer.
      *
      * @param {string} topicName
      * @param {ArchivistIndex} index
@@ -169,7 +171,7 @@ declare class Archivist {
     touch(topicName: string, index: mage.archivist.IArchivistIndex, expirationTime?: number): void;
 
     /**
-     *
+     * Commit all current changes to their respective vault backend(s)
      *
      * @param {*} [options]
      * @param {(preDistributionErrors: Error[], distributionErrors: Error[]) => void} callback
@@ -177,6 +179,13 @@ declare class Archivist {
      * @memberOf Archivist
      */
     distribute(callback: mage.archivist.ArchivistDistributeCallback): void;
+
+    /**
+     * Clear all the loaded entries from this archivist instance
+     *
+     * @memberOf Archivist
+     */
+    clearCache(): void;
 }
 
 /**
@@ -2315,14 +2324,6 @@ declare namespace mage {
              * A description of what this state is being used for
              */
             description?: string;
-
-            /**
-             * Actor lookup cache timeout
-             *
-             * By default, the lookup cache will be set
-             * to 500 milliseconds.
-             */
-            cacheTimeout?: number
 
             /**
              * State metadata

--- a/mage.ts
+++ b/mage.ts
@@ -2317,13 +2317,6 @@ declare namespace mage {
             description?: string;
 
             /**
-             * Timeout, in milliseconds
-             *
-             * Upon timeout, the state will close automatically.
-             */
-            timeout?: number
-
-            /**
              * Actor lookup cache timeout
              *
              * By default, the lookup cache will be set

--- a/mage.ts
+++ b/mage.ts
@@ -2119,7 +2119,23 @@ declare namespace mage {
          * @interface IUserCommand
          */
         interface IUserCommand {
+            /**
+             * What user levels are allowed to access
+             * this user command
+             */
             acl?: string[];
+
+            /**
+             * Timeout for the user command
+             *
+             * By default, the user command will be allowed
+             * to run forever.
+             */
+            timeout?: number;
+
+            /**
+             * The code of the user command itself
+             */
             execute<T>(state: IState, ...args: any[]): Promise<T>;
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,15 +82,15 @@
       "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c="
     },
     "abbrev": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+      "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
       "dev": true
     },
     "acorn": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
-      "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0=",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
+      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
       "dev": true
     },
     "acorn-es7-plugin": {
@@ -168,6 +168,22 @@
       "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
       "integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU="
     },
+    "aproba": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
+      "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
+      "dev": true
+    },
+    "are-we-there-yet": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "dev": true,
+      "requires": {
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.3"
+      }
+    },
     "argparse": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
@@ -216,9 +232,9 @@
       "dev": true
     },
     "asap": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
-      "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8=",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true
     },
     "asn1": {
@@ -257,26 +273,26 @@
       "dev": true
     },
     "babel-code-frame": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "esutils": "2.0.2",
-        "js-tokens": "3.0.1"
+        "js-tokens": "3.0.2"
       }
     },
     "babylon": {
-      "version": "6.17.1",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.1.tgz",
-      "integrity": "sha1-F/FP3fNhtpWYH+Z5OF5PHAHr2G8=",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
     "balanced-match": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
@@ -295,9 +311,18 @@
       "dev": true
     },
     "bindings": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
     },
     "boom": {
       "version": "2.10.1",
@@ -309,11 +334,11 @@
       }
     },
     "brace-expansion": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-      "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "0.4.2",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -321,12 +346,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
-      "dev": true
-    },
-    "buffer-shims": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
       "dev": true
     },
     "builtin-modules": {
@@ -391,9 +410,9 @@
       }
     },
     "circular-json": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
-      "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "cli": {
@@ -416,9 +435,9 @@
       }
     },
     "cli-width": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "cliui": {
@@ -460,12 +479,6 @@
         "semver": "5.3.0"
       }
     },
-    "colors": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
-      "dev": true
-    },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
@@ -495,7 +508,7 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.2.9",
+        "readable-stream": "2.3.3",
         "typedarray": "0.0.6"
       }
     },
@@ -508,10 +521,16 @@
         "date-now": "0.1.4"
       }
     },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
+    },
     "core-js": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
       "dev": true
     },
     "core-util-is": {
@@ -573,9 +592,21 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.0.2",
+        "lru-cache": "4.1.1",
         "shebang-command": "1.2.0",
-        "which": "1.2.14"
+        "which": "1.3.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        }
       }
     },
     "cryptiles": {
@@ -592,7 +623,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "0.10.21"
+        "es5-ext": "0.10.30"
       }
     },
     "dashdash": {
@@ -635,6 +666,18 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "optional": true
     },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
+    "deep-extend": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+      "dev": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -651,6 +694,12 @@
         "object-keys": "1.0.11"
       }
     },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
     "del": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
@@ -664,6 +713,14 @@
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
         "rimraf": "2.6.1"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        }
       }
     },
     "delayed-stream": {
@@ -672,13 +729,19 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
+    },
     "dezalgo": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
       "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
       "dev": true,
       "requires": {
-        "asap": "2.0.5",
+        "asap": "2.0.6",
         "wrappy": "1.0.2"
       }
     },
@@ -776,23 +839,23 @@
       }
     },
     "empower": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/empower/-/empower-1.2.1.tgz",
-      "integrity": "sha1-tjMCdBttUDokG/8RW+/JSMg2LGA=",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/empower/-/empower-1.2.3.tgz",
+      "integrity": "sha1-bw2nNEf07dg4/sXGAxOoi6XLhSs=",
       "dev": true,
       "requires": {
-        "core-js": "2.4.1",
-        "empower-core": "0.6.1"
+        "core-js": "2.5.1",
+        "empower-core": "0.6.2"
       }
     },
     "empower-core": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/empower-core/-/empower-core-0.6.1.tgz",
-      "integrity": "sha1-bBh/UC/O91VNV5MzlqrGVUg3crE=",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/empower-core/-/empower-core-0.6.2.tgz",
+      "integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
       "dev": true,
       "requires": {
         "call-signature": "0.0.2",
-        "core-js": "2.4.1"
+        "core-js": "2.5.1"
       }
     },
     "entities": {
@@ -816,13 +879,14 @@
       }
     },
     "es-abstract": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
-      "integrity": "sha1-363ndOAb/Nl/lhgCmMRJyGI/uUw=",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.2.tgz",
+      "integrity": "sha512-dvhwFL3yjQxNNsOWx6exMlaDrRHCRGMQlnx5lsXDCZ/J7G/frgIIl94zhZSp/galVAYp7VzPi1OrAHta89/yGQ==",
       "dev": true,
       "requires": {
         "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.0",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
         "is-callable": "1.1.3",
         "is-regex": "1.0.4"
       }
@@ -839,9 +903,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.21",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.21.tgz",
-      "integrity": "sha1-Gacl+eUdAwC7wejoIRCf2dr1WSU=",
+      "version": "0.10.30",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.30.tgz",
+      "integrity": "sha1-cUGhaDZpfbq/qq7uQUlc4p9SyTk=",
       "requires": {
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1"
@@ -853,7 +917,7 @@
       "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.21",
+        "es5-ext": "0.10.30",
         "es6-symbol": "3.1.1"
       }
     },
@@ -864,7 +928,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.21",
+        "es5-ext": "0.10.30",
         "es6-iterator": "2.0.1",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -878,7 +942,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.21",
+        "es5-ext": "0.10.30",
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -890,7 +954,7 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.21"
+        "es5-ext": "0.10.30"
       }
     },
     "es6-weak-map": {
@@ -899,7 +963,7 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.21",
+        "es5-ext": "0.10.30",
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1"
       }
@@ -991,7 +1055,7 @@
       "requires": {
         "es6-map": "0.1.5",
         "es6-weak-map": "2.0.2",
-        "esrecurse": "4.1.0",
+        "esrecurse": "4.2.0",
         "estraverse": "4.2.0"
       }
     },
@@ -1001,23 +1065,23 @@
       "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.22.0",
+        "babel-code-frame": "6.26.0",
         "chalk": "1.1.3",
         "concat-stream": "1.6.0",
         "debug": "2.6.8",
         "doctrine": "2.0.0",
         "escope": "3.6.0",
-        "espree": "3.4.3",
+        "espree": "3.5.0",
         "esquery": "1.0.0",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
         "glob": "7.1.2",
-        "globals": "9.17.0",
-        "ignore": "3.3.3",
+        "globals": "9.18.0",
+        "ignore": "3.3.5",
         "imurmurhash": "0.1.4",
         "inquirer": "0.12.0",
-        "is-my-json-valid": "2.16.0",
+        "is-my-json-valid": "2.16.1",
         "is-resolvable": "1.0.0",
         "js-yaml": "3.8.4",
         "json-stable-stringify": "1.0.1",
@@ -1030,7 +1094,7 @@
         "pluralize": "1.2.1",
         "progress": "1.1.8",
         "require-uncached": "1.0.3",
-        "shelljs": "0.7.7",
+        "shelljs": "0.7.8",
         "strip-bom": "3.0.0",
         "strip-json-comments": "2.0.1",
         "table": "3.8.3",
@@ -1046,6 +1110,18 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
         }
       }
     },
@@ -1055,7 +1131,7 @@
       "integrity": "sha1-m6c7sL6Z1QCT6In1uWhGPSow764=",
       "dev": true,
       "requires": {
-        "jshint": "2.9.4"
+        "jshint": "2.9.5"
       }
     },
     "eslint-plugin-mocha": {
@@ -1068,12 +1144,12 @@
       }
     },
     "espree": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
-      "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
+      "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
       "dev": true,
       "requires": {
-        "acorn": "5.0.3",
+        "acorn": "5.1.2",
         "acorn-jsx": "3.0.1"
       }
     },
@@ -1088,7 +1164,7 @@
       "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
       "dev": true,
       "requires": {
-        "core-js": "2.4.1"
+        "core-js": "2.5.1"
       }
     },
     "esquery": {
@@ -1101,19 +1177,19 @@
       }
     },
     "esrecurse": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
-      "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "dev": true,
       "requires": {
-        "estraverse": "4.1.1",
+        "estraverse": "4.2.0",
         "object-assign": "4.1.1"
       },
       "dependencies": {
-        "estraverse": {
+        "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
-          "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         }
       }
@@ -1136,7 +1212,7 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.21"
+        "es5-ext": "0.10.30"
       }
     },
     "event-stream": {
@@ -1152,6 +1228,17 @@
         "split": "0.3.3",
         "stream-combiner": "0.0.4",
         "through": "2.3.8"
+      },
+      "dependencies": {
+        "stream-combiner": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+          "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+          "dev": true,
+          "requires": {
+            "duplexer": "0.1.1"
+          }
+        }
       }
     },
     "events": {
@@ -1178,9 +1265,9 @@
       "dev": true
     },
     "extsprintf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
     "fast-levenshtein": {
@@ -1197,6 +1284,14 @@
       "requires": {
         "escape-string-regexp": "1.0.5",
         "object-assign": "4.1.1"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        }
       }
     },
     "file-entry-cache": {
@@ -1207,6 +1302,14 @@
       "requires": {
         "flat-cache": "1.2.2",
         "object-assign": "4.1.1"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        }
       }
     },
     "flat-cache": {
@@ -1215,10 +1318,19 @@
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.1",
+        "circular-json": "0.3.3",
         "del": "2.2.2",
         "graceful-fs": "4.1.11",
         "write": "0.2.1"
+      }
+    },
+    "for-each": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
+      "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
+      "dev": true,
+      "requires": {
+        "is-function": "1.0.1"
       }
     },
     "foreach": {
@@ -1241,7 +1353,7 @@
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
-        "mime-types": "2.1.15"
+        "mime-types": "2.1.17"
       }
     },
     "format-error": {
@@ -1265,7 +1377,6 @@
           "integrity": "sha1-keaUCoqU8ZH5KyVu9VG59J+t7v8=",
           "dev": true,
           "requires": {
-            "colors": "0.6.2",
             "minimist": "0.0.8"
           }
         }
@@ -1300,16 +1411,63 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "fstream": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.1"
+      }
+    },
+    "fstream-ignore": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+      "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+      "dev": true,
+      "requires": {
+        "fstream": "1.0.11",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4"
+      }
+    },
     "function-arguments": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/function-arguments/-/function-arguments-1.0.8.tgz",
       "integrity": "sha1-uaAdrKa4lO/4w9NoQDde2WNqbA8="
     },
     "function-bind": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
+      "requires": {
+        "aproba": "1.1.2",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.2"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        }
+      }
     },
     "generate-function": {
       "version": "2.0.0",
@@ -1349,17 +1507,23 @@
       "integrity": "sha1-9QGV/sQnotA30zOjIqpqG5UAVms=",
       "dev": true,
       "requires": {
-        "async": "2.4.1"
+        "async": "2.5.0"
       },
       "dependencies": {
         "async": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
-          "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c=",
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "dev": true,
           "requires": {
             "lodash": "4.17.4"
           }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         }
       }
     },
@@ -1377,9 +1541,9 @@
       }
     },
     "globals": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
-      "integrity": "sha1-DAymltm5u2lNLlRwvTd3fKrVAoY=",
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
     "globby": {
@@ -1394,6 +1558,14 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        }
       }
     },
     "graceful-fs": {
@@ -1421,7 +1593,7 @@
         "async": "1.5.2",
         "optimist": "0.6.1",
         "source-map": "0.4.4",
-        "uglify-js": "2.8.27"
+        "uglify-js": "2.8.29"
       },
       "dependencies": {
         "async": {
@@ -1439,6 +1611,12 @@
         }
       }
     },
+    "har-schema": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+      "dev": true
+    },
     "har-validator": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
@@ -1447,7 +1625,7 @@
       "requires": {
         "chalk": "1.1.3",
         "commander": "2.9.0",
-        "is-my-json-valid": "2.16.0",
+        "is-my-json-valid": "2.16.1",
         "pinkie-promise": "2.0.1"
       }
     },
@@ -1457,7 +1635,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.0"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -1477,6 +1655,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
     "hawk": {
@@ -1509,9 +1693,9 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-      "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
     "htmlparser2": {
@@ -1568,14 +1752,14 @@
       "dev": true,
       "requires": {
         "assert-plus": "0.2.0",
-        "jsprim": "1.4.0",
-        "sshpk": "1.13.0"
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
       }
     },
     "ignore": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
-      "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
+      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
       "dev": true
     },
     "imurmurhash": {
@@ -1604,6 +1788,12 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "ini": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+      "dev": true
+    },
     "inquirer": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
@@ -1614,7 +1804,7 @@
         "ansi-regex": "2.1.1",
         "chalk": "1.1.3",
         "cli-cursor": "1.0.2",
-        "cli-width": "2.1.0",
+        "cli-width": "2.2.0",
         "figures": "1.7.0",
         "lodash": "4.17.4",
         "readline2": "1.0.1",
@@ -1623,6 +1813,14 @@
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1",
         "through": "2.3.8"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        }
       }
     },
     "interpret": {
@@ -1672,16 +1870,30 @@
         "number-is-nan": "1.0.1"
       }
     },
+    "is-function": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
+      "dev": true
+    },
     "is-my-json-valid": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
+      "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
       "dev": true,
       "requires": {
         "generate-function": "2.0.0",
         "generate-object-property": "1.2.0",
         "jsonpointer": "4.0.1",
         "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+          "dev": true
+        }
       }
     },
     "is-path-cwd": {
@@ -1791,10 +2003,16 @@
         "once": "1.4.0",
         "resolve": "1.1.7",
         "supports-color": "3.2.3",
-        "which": "1.2.14",
+        "which": "1.3.0",
         "wordwrap": "1.0.0"
       },
       "dependencies": {
+        "abbrev": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+          "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+          "dev": true
+        },
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
@@ -1843,26 +2061,10 @@
         }
       }
     },
-    "jju": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
-      "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
-      "dev": true
-    },
-    "jodid25519": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "jsbn": "0.1.1"
-      }
-    },
     "js-tokens": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-      "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
     "js-yaml": {
@@ -1882,9 +2084,9 @@
       "optional": true
     },
     "jshint": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.4.tgz",
-      "integrity": "sha1-XjupeEjVKQJz21FK7kf+JM9ZKTQ=",
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
+      "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
       "dev": true,
       "requires": {
         "cli": "1.0.1",
@@ -1917,14 +2119,11 @@
         }
       }
     },
-    "json-parse-helpfulerror": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
-      "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
-      "dev": true,
-      "requires": {
-        "jju": "1.3.0"
-      }
+    "json-parse-better-errors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
+      "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
@@ -1989,15 +2188,15 @@
       "dev": true
     },
     "jsprim": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
-        "extsprintf": "1.0.2",
+        "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
-        "verror": "1.3.6"
+        "verror": "1.10.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -2047,28 +2246,10 @@
         "type-check": "0.3.2"
       }
     },
-    "load-json-file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "strip-bom": "3.0.0"
-      }
-    },
     "localstash": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/localstash/-/localstash-0.2.0.tgz",
       "integrity": "sha1-hSiITinXK6lWSVTh4LuGukJsey0="
-    },
-    "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-      "dev": true
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -2149,22 +2330,12 @@
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
-    "lru-cache": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
-      "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
-      "dev": true,
-      "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
-      }
-    },
     "lru-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
       "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
       "requires": {
-        "es5-ext": "0.10.21"
+        "es5-ext": "0.10.30"
       }
     },
     "map-stream": {
@@ -2185,7 +2356,7 @@
       "integrity": "sha1-7PS3kaCc0RyXAgP4BoJTRzD6148=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.21",
+        "es5-ext": "0.10.30",
         "es6-weak-map": "2.0.2",
         "event-emitter": "0.3.5",
         "is-promise": "2.1.0",
@@ -2199,8 +2370,8 @@
       "resolved": "https://registry.npmjs.org/memwatch-next/-/memwatch-next-0.3.0.tgz",
       "integrity": "sha1-IREFD5qQbgqi1ypOwPAInHhyb48=",
       "requires": {
-        "bindings": "1.2.1",
-        "nan": "2.6.2"
+        "bindings": "1.3.0",
+        "nan": "2.7.0"
       }
     },
     "mime": {
@@ -2209,18 +2380,18 @@
       "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA="
     },
     "mime-db": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.15",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "dev": true,
       "requires": {
-        "mime-db": "1.27.0"
+        "mime-db": "1.30.0"
       }
     },
     "minimatch": {
@@ -2228,7 +2399,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.7"
+        "brace-expansion": "1.1.8"
       }
     },
     "minimist": {
@@ -2388,9 +2559,9 @@
       }
     },
     "nan": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
+      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -2407,6 +2578,103 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+    },
+    "node-pre-gyp": {
+      "version": "0.6.37",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.37.tgz",
+      "integrity": "sha1-PIcrI2suJm5BQFeP4e6I9pMyOgU=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1",
+        "nopt": "4.0.1",
+        "npmlog": "4.1.2",
+        "rc": "1.2.1",
+        "request": "2.81.0",
+        "rimraf": "2.6.1",
+        "semver": "5.3.0",
+        "tape": "4.8.0",
+        "tar": "2.2.1",
+        "tar-pack": "3.4.0"
+      },
+      "dependencies": {
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+          "dev": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "dev": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "qs": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.81.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.1.0"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+          "dev": true
+        }
+      }
     },
     "node-uuid": {
       "version": "1.4.7",
@@ -2450,16 +2718,16 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9"
+        "abbrev": "1.1.0"
       }
     },
     "normalize-package-data": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-      "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.4.2",
+        "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
         "semver": "5.3.0",
         "validate-npm-package-license": "3.0.1"
@@ -2478,6 +2746,58 @@
         "read-pkg": "2.0.0",
         "shell-quote": "1.6.1",
         "string.prototype.padend": "3.0.0"
+      },
+      "dependencies": {
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "2.3.0"
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
+      "requires": {
+        "are-we-there-yet": "1.1.4",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
       }
     },
     "number-is-nan": {
@@ -2492,10 +2812,10 @@
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
       "dev": true
     },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+    "object-inspect": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.3.0.tgz",
+      "integrity": "sha512-OHHnLgLNXpM++GnJRyyhbr2bwl3pPVm4YvaraHrRvDt/N3r+s/gDVHciA7EJBTkijKXj61ssgSAikq1fb0IBRg==",
       "dev": true
     },
     "object-keys": {
@@ -2560,6 +2880,22 @@
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "osenv": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
+    },
     "panopticon": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/panopticon/-/panopticon-0.2.0.tgz",
@@ -2591,15 +2927,6 @@
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
-    "path-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-      "dev": true,
-      "requires": {
-        "pify": "2.3.0"
-      }
-    },
     "pause-stream": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
@@ -2608,6 +2935,12 @@
       "requires": {
         "through": "2.3.8"
       }
+    },
+    "performance-now": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+      "dev": true
     },
     "pify": {
       "version": "2.3.0",
@@ -2639,7 +2972,7 @@
         "eslint": "3.0.1",
         "fs-extra": "0.30.0",
         "glob": "7.0.6",
-        "jshint": "2.9.4",
+        "jshint": "2.9.5",
         "lodash": "4.13.1",
         "posix-getopt": "1.2.0",
         "typhonjs-escomplex": "0.0.9"
@@ -2676,16 +3009,16 @@
             "doctrine": "1.5.0",
             "es6-map": "0.1.5",
             "escope": "3.6.0",
-            "espree": "3.4.3",
+            "espree": "3.5.0",
             "estraverse": "4.2.0",
             "esutils": "2.0.2",
             "file-entry-cache": "1.3.1",
             "glob": "7.0.6",
-            "globals": "9.17.0",
-            "ignore": "3.3.3",
+            "globals": "9.18.0",
+            "ignore": "3.3.5",
             "imurmurhash": "0.1.4",
             "inquirer": "0.12.0",
-            "is-my-json-valid": "2.16.0",
+            "is-my-json-valid": "2.16.1",
             "is-resolvable": "1.0.0",
             "js-yaml": "3.8.4",
             "json-stable-stringify": "1.0.1",
@@ -2735,10 +3068,22 @@
           "integrity": "sha1-g+SxCRP0hJbU0W/sSlYK8u50S2g=",
           "dev": true
         },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        },
         "shelljs": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
           "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         },
         "strip-json-comments": {
@@ -2768,10 +3113,18 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "empower": "1.2.1",
+        "empower": "1.2.3",
         "power-assert-formatter": "1.4.1",
         "universal-deep-strict-equal": "1.2.2",
         "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+          "dev": true
+        }
       }
     },
     "power-assert-context-formatter": {
@@ -2780,7 +3133,7 @@
       "integrity": "sha1-7bo1LT7YpgMRTWZyZazOYNaJzN8=",
       "dev": true,
       "requires": {
-        "core-js": "2.4.1",
+        "core-js": "2.5.1",
         "power-assert-context-traversal": "1.1.1"
       }
     },
@@ -2792,7 +3145,7 @@
       "requires": {
         "acorn": "4.0.13",
         "acorn-es7-plugin": "1.1.7",
-        "core-js": "2.4.1",
+        "core-js": "2.5.1",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
       },
@@ -2811,7 +3164,7 @@
       "integrity": "sha1-iMq8oNE7Y1nwfT0+ivppkmRXftk=",
       "dev": true,
       "requires": {
-        "core-js": "2.4.1",
+        "core-js": "2.5.1",
         "estraverse": "4.2.0"
       }
     },
@@ -2821,7 +3174,7 @@
       "integrity": "sha1-XcEl7VCj37HdomwZNH879Y7CiEo=",
       "dev": true,
       "requires": {
-        "core-js": "2.4.1",
+        "core-js": "2.5.1",
         "power-assert-context-formatter": "1.1.1",
         "power-assert-context-reducer-ast": "1.1.2",
         "power-assert-renderer-assertion": "1.1.1",
@@ -2852,7 +3205,7 @@
       "integrity": "sha1-10Odl9hRVr5OMKAPL7WnJRTOPAg=",
       "dev": true,
       "requires": {
-        "core-js": "2.4.1",
+        "core-js": "2.5.1",
         "diff-match-patch": "1.0.0",
         "power-assert-renderer-base": "1.1.1",
         "stringifier": "1.3.0",
@@ -2865,7 +3218,7 @@
       "integrity": "sha1-ZV+PcRk1qbbVQbhjJ2VHF8Y3qYY=",
       "dev": true,
       "requires": {
-        "core-js": "2.4.1",
+        "core-js": "2.5.1",
         "power-assert-renderer-base": "1.1.1",
         "power-assert-util-string-width": "1.1.1",
         "stringifier": "1.3.0"
@@ -2949,17 +3302,31 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true
     },
-    "qs": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-      "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
-      "dev": true
-    },
     "ramda": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.23.0.tgz",
       "integrity": "sha1-zNE//3NJepOXTj6GMnv9h71ujis=",
       "dev": true
+    },
+    "rc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+      "dev": true,
+      "requires": {
+        "deep-extend": "0.4.2",
+        "ini": "1.3.4",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
     },
     "read-installed": {
       "version": "4.0.3",
@@ -2969,7 +3336,7 @@
       "requires": {
         "debuglog": "1.0.1",
         "graceful-fs": "4.1.11",
-        "read-package-json": "2.0.5",
+        "read-package-json": "2.0.12",
         "readdir-scoped-modules": "1.0.2",
         "semver": "5.3.0",
         "slide": "1.1.6",
@@ -2977,40 +3344,30 @@
       }
     },
     "read-package-json": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.5.tgz",
-      "integrity": "sha1-+Tpk5kFSnfaKCMZN5GOJ6KP4iEU=",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.12.tgz",
+      "integrity": "sha512-m7/I0+tP6D34EVvSlzCtuVA4D/dHL6OpLcn2e4XVP5X57pCKGUy1JjRSBVKHWpB+vUU91sL85h84qX0MdXzBSw==",
       "dev": true,
       "requires": {
         "glob": "7.1.2",
         "graceful-fs": "4.1.11",
-        "json-parse-helpfulerror": "1.0.3",
-        "normalize-package-data": "2.3.8"
-      }
-    },
-    "read-pkg": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-      "dev": true,
-      "requires": {
-        "load-json-file": "2.0.0",
-        "normalize-package-data": "2.3.8",
-        "path-type": "2.0.0"
+        "json-parse-better-errors": "1.0.1",
+        "normalize-package-data": "2.4.0",
+        "slash": "1.0.0"
       }
     },
     "readable-stream": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-      "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true,
       "requires": {
-        "buffer-shims": "1.0.0",
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
         "isarray": "1.0.0",
         "process-nextick-args": "1.0.7",
-        "string_decoder": "1.0.1",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
         "util-deprecate": "1.0.2"
       }
     },
@@ -3043,7 +3400,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.3.3"
+        "resolve": "1.4.0"
       }
     },
     "repeat-string": {
@@ -3070,19 +3427,25 @@
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.15",
+        "mime-types": "2.1.17",
         "oauth-sign": "0.8.2",
         "qs": "6.3.2",
         "stringstream": "0.0.5",
         "tough-cookie": "2.3.2",
         "tunnel-agent": "0.4.3",
-        "uuid": "3.0.1"
+        "uuid": "3.1.0"
       },
       "dependencies": {
+        "qs": {
+          "version": "6.3.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+          "dev": true
+        },
         "uuid": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
           "dev": true
         }
       }
@@ -3104,9 +3467,9 @@
       }
     },
     "resolve": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
-      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
       "dev": true,
       "requires": {
         "path-parse": "1.0.5"
@@ -3126,6 +3489,15 @@
       "requires": {
         "exit-hook": "1.1.1",
         "onetime": "1.1.0"
+      }
+    },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
       }
     },
     "retire": {
@@ -3186,15 +3558,26 @@
       "dev": true
     },
     "safe-buffer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
+    },
+    "safe-timers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safe-timers/-/safe-timers-1.0.1.tgz",
+      "integrity": "sha1-40VJ8/d95SLv1dbvfyl0aIl5sMg="
     },
     "semver": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
       "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -3224,15 +3607,27 @@
       }
     },
     "shelljs": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
-      "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E=",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true,
       "requires": {
         "glob": "7.1.2",
         "interpret": "1.0.3",
         "rechoir": "0.6.2"
       }
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "dev": true
     },
     "slice-ansi": {
       "version": "0.0.4",
@@ -3305,7 +3700,7 @@
       "dev": true,
       "requires": {
         "nan": "2.4.0",
-        "node-pre-gyp": "0.6.31"
+        "node-pre-gyp": "0.6.37"
       },
       "dependencies": {
         "nan": {
@@ -3313,1230 +3708,13 @@
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
           "integrity": "sha1-+zxZ1F/k7/4hXwuJD4rfbrMtIjI=",
           "dev": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.31",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.31.tgz",
-          "integrity": "sha1-2KAN2qMBqUBhXbzIyq1AJNWPYBc=",
-          "dev": true,
-          "requires": {
-            "mkdirp": "0.5.1",
-            "nopt": "3.0.6",
-            "npmlog": "4.0.0",
-            "rc": "1.1.6",
-            "request": "2.76.0",
-            "rimraf": "2.5.4",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.3.0"
-          },
-          "dependencies": {
-            "mkdirp": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "dev": true,
-              "requires": {
-                "minimist": "0.0.8"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                  "dev": true
-                }
-              }
-            },
-            "nopt": {
-              "version": "3.0.6",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-              "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-              "dev": true,
-              "requires": {
-                "abbrev": "1.0.9"
-              },
-              "dependencies": {
-                "abbrev": {
-                  "version": "1.0.9",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-                  "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
-                  "dev": true
-                }
-              }
-            },
-            "npmlog": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.0.tgz",
-              "integrity": "sha1-4JRQOWHHDBd063ZpIIDo1Xip+I8=",
-              "dev": true,
-              "requires": {
-                "are-we-there-yet": "1.1.2",
-                "console-control-strings": "1.1.0",
-                "gauge": "2.6.0",
-                "set-blocking": "2.0.0"
-              },
-              "dependencies": {
-                "are-we-there-yet": {
-                  "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-                  "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
-                  "dev": true,
-                  "requires": {
-                    "delegates": "1.0.0",
-                    "readable-stream": "2.1.5"
-                  },
-                  "dependencies": {
-                    "delegates": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-                      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-                      "dev": true
-                    },
-                    "readable-stream": {
-                      "version": "2.1.5",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-                      "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
-                      "dev": true,
-                      "requires": {
-                        "buffer-shims": "1.0.0",
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "0.10.31",
-                        "util-deprecate": "1.0.2"
-                      },
-                      "dependencies": {
-                        "buffer-shims": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-                          "dev": true
-                        },
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-                          "dev": true
-                        },
-                        "inherits": {
-                          "version": "2.0.3",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                          "dev": true
-                        },
-                        "isarray": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                          "dev": true
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.7",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-                          "dev": true
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                          "dev": true
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "console-control-strings": {
-                  "version": "1.1.0",
-                  "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-                  "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-                  "dev": true
-                },
-                "gauge": {
-                  "version": "2.6.0",
-                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
-                  "integrity": "sha1-01MBrRjpaQK0dR3LvkD0IYuUKkY=",
-                  "dev": true,
-                  "requires": {
-                    "aproba": "1.0.4",
-                    "console-control-strings": "1.1.0",
-                    "has-color": "0.1.7",
-                    "has-unicode": "2.0.1",
-                    "object-assign": "4.1.0",
-                    "signal-exit": "3.0.1",
-                    "string-width": "1.0.2",
-                    "strip-ansi": "3.0.1",
-                    "wide-align": "1.1.0"
-                  },
-                  "dependencies": {
-                    "aproba": {
-                      "version": "1.0.4",
-                      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
-                      "integrity": "sha1-JxNoB3XnYUyLoYbAZdTi5S0QcsA=",
-                      "dev": true
-                    },
-                    "has-color": {
-                      "version": "0.1.7",
-                      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-                      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
-                      "dev": true
-                    },
-                    "has-unicode": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-                      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-                      "dev": true
-                    },
-                    "object-assign": {
-                      "version": "4.1.0",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-                      "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
-                      "dev": true
-                    },
-                    "signal-exit": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
-                      "integrity": "sha1-WkyISZK2OnrNm623iUw+6c/MrYE=",
-                      "dev": true
-                    },
-                    "string-width": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                      "dev": true,
-                      "requires": {
-                        "code-point-at": "1.0.1",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                      },
-                      "dependencies": {
-                        "code-point-at": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
-                          "integrity": "sha1-EQTNNPm1tF0+uojxurwZJOHONfs=",
-                          "dev": true,
-                          "requires": {
-                            "number-is-nan": "1.0.1"
-                          },
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                              "dev": true
-                            }
-                          }
-                        },
-                        "is-fullwidth-code-point": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                          "dev": true,
-                          "requires": {
-                            "number-is-nan": "1.0.1"
-                          },
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                      "dev": true,
-                      "requires": {
-                        "ansi-regex": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "wide-align": {
-                      "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
-                      "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
-                      "dev": true,
-                      "requires": {
-                        "string-width": "1.0.2"
-                      }
-                    }
-                  }
-                },
-                "set-blocking": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-                  "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-                  "dev": true
-                }
-              }
-            },
-            "rc": {
-              "version": "1.1.6",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-              "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
-              "dev": true,
-              "requires": {
-                "deep-extend": "0.4.1",
-                "ini": "1.3.4",
-                "minimist": "1.2.0",
-                "strip-json-comments": "1.0.4"
-              },
-              "dependencies": {
-                "deep-extend": {
-                  "version": "0.4.1",
-                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-                  "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
-                  "dev": true
-                },
-                "ini": {
-                  "version": "1.3.4",
-                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-                  "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-                  "dev": true
-                },
-                "minimist": {
-                  "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                  "dev": true
-                },
-                "strip-json-comments": {
-                  "version": "1.0.4",
-                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-                  "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
-                  "dev": true
-                }
-              }
-            },
-            "request": {
-              "version": "2.76.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.76.0.tgz",
-              "integrity": "sha1-vkRQWv73A2CgQ2lVEGvjlF2VVg4=",
-              "dev": true,
-              "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.5.0",
-                "caseless": "0.11.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.0",
-                "forever-agent": "0.6.1",
-                "form-data": "2.1.1",
-                "har-validator": "2.0.6",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.12",
-                "node-uuid": "1.4.7",
-                "oauth-sign": "0.8.2",
-                "qs": "6.3.0",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.2",
-                "tunnel-agent": "0.4.3"
-              },
-              "dependencies": {
-                "aws-sign2": {
-                  "version": "0.6.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                  "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-                  "dev": true
-                },
-                "aws4": {
-                  "version": "1.5.0",
-                  "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
-                  "integrity": "sha1-Cin/t5wxyecS7rCH6OemS0pW11U=",
-                  "dev": true
-                },
-                "caseless": {
-                  "version": "0.11.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-                  "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-                  "dev": true
-                },
-                "combined-stream": {
-                  "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                  "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-                  "dev": true,
-                  "requires": {
-                    "delayed-stream": "1.0.0"
-                  },
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-                      "dev": true
-                    }
-                  }
-                },
-                "extend": {
-                  "version": "3.0.0",
-                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-                  "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
-                  "dev": true
-                },
-                "forever-agent": {
-                  "version": "0.6.1",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                  "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-                  "dev": true
-                },
-                "form-data": {
-                  "version": "2.1.1",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.1.tgz",
-                  "integrity": "sha1-St8DQuGnmvoehMjDIKn/yCOSofM=",
-                  "dev": true,
-                  "requires": {
-                    "asynckit": "0.4.0",
-                    "combined-stream": "1.0.5",
-                    "mime-types": "2.1.12"
-                  },
-                  "dependencies": {
-                    "asynckit": {
-                      "version": "0.4.0",
-                      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-                      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-                      "dev": true
-                    }
-                  }
-                },
-                "har-validator": {
-                  "version": "2.0.6",
-                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-                  "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-                  "dev": true,
-                  "requires": {
-                    "chalk": "1.1.3",
-                    "commander": "2.9.0",
-                    "is-my-json-valid": "2.15.0",
-                    "pinkie-promise": "2.0.1"
-                  },
-                  "dependencies": {
-                    "chalk": {
-                      "version": "1.1.3",
-                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                      "dev": true,
-                      "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ansi-styles": {
-                          "version": "2.2.1",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                          "dev": true
-                        },
-                        "escape-string-regexp": {
-                          "version": "1.0.5",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-                          "dev": true
-                        },
-                        "has-ansi": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-                          "dev": true,
-                          "requires": {
-                            "ansi-regex": "2.0.0"
-                          },
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
-                              "dev": true
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                          "dev": true,
-                          "requires": {
-                            "ansi-regex": "2.0.0"
-                          },
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
-                              "dev": true
-                            }
-                          }
-                        },
-                        "supports-color": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "commander": {
-                      "version": "2.9.0",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-                      "dev": true,
-                      "requires": {
-                        "graceful-readlink": "1.0.1"
-                      },
-                      "dependencies": {
-                        "graceful-readlink": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                          "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "is-my-json-valid": {
-                      "version": "2.15.0",
-                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
-                      "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
-                      "dev": true,
-                      "requires": {
-                        "generate-function": "2.0.0",
-                        "generate-object-property": "1.2.0",
-                        "jsonpointer": "4.0.0",
-                        "xtend": "4.0.1"
-                      },
-                      "dependencies": {
-                        "generate-function": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                          "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-                          "dev": true
-                        },
-                        "generate-object-property": {
-                          "version": "1.2.0",
-                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                          "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-                          "dev": true,
-                          "requires": {
-                            "is-property": "1.0.2"
-                          },
-                          "dependencies": {
-                            "is-property": {
-                              "version": "1.0.2",
-                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                              "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-                              "dev": true
-                            }
-                          }
-                        },
-                        "jsonpointer": {
-                          "version": "4.0.0",
-                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz",
-                          "integrity": "sha1-ZmHhYdL8RF8Z+YQwIxNDci4fy9U=",
-                          "dev": true
-                        },
-                        "xtend": {
-                          "version": "4.0.1",
-                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "pinkie-promise": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-                      "dev": true,
-                      "requires": {
-                        "pinkie": "2.0.4"
-                      },
-                      "dependencies": {
-                        "pinkie": {
-                          "version": "2.0.4",
-                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "hawk": {
-                  "version": "3.1.3",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-                  "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-                  "dev": true,
-                  "requires": {
-                    "boom": "2.10.1",
-                    "cryptiles": "2.0.5",
-                    "hoek": "2.16.3",
-                    "sntp": "1.0.9"
-                  },
-                  "dependencies": {
-                    "boom": {
-                      "version": "2.10.1",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-                      "dev": true,
-                      "requires": {
-                        "hoek": "2.16.3"
-                      }
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-                      "dev": true,
-                      "requires": {
-                        "boom": "2.10.1"
-                      }
-                    },
-                    "hoek": {
-                      "version": "2.16.3",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-                      "dev": true
-                    },
-                    "sntp": {
-                      "version": "1.0.9",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-                      "dev": true,
-                      "requires": {
-                        "hoek": "2.16.3"
-                      }
-                    }
-                  }
-                },
-                "http-signature": {
-                  "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-                  "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-                  "dev": true,
-                  "requires": {
-                    "assert-plus": "0.2.0",
-                    "jsprim": "1.3.1",
-                    "sshpk": "1.10.1"
-                  },
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.2.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-                      "dev": true
-                    },
-                    "jsprim": {
-                      "version": "1.3.1",
-                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
-                      "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
-                      "dev": true,
-                      "requires": {
-                        "extsprintf": "1.0.2",
-                        "json-schema": "0.2.3",
-                        "verror": "1.3.6"
-                      },
-                      "dependencies": {
-                        "extsprintf": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-                          "dev": true
-                        },
-                        "json-schema": {
-                          "version": "0.2.3",
-                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-                          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-                          "dev": true
-                        },
-                        "verror": {
-                          "version": "1.3.6",
-                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-                          "dev": true,
-                          "requires": {
-                            "extsprintf": "1.0.2"
-                          }
-                        }
-                      }
-                    },
-                    "sshpk": {
-                      "version": "1.10.1",
-                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
-                      "integrity": "sha1-MOGl0ykkSXShr2FREznVla9mOLA=",
-                      "dev": true,
-                      "requires": {
-                        "asn1": "0.2.3",
-                        "assert-plus": "1.0.0",
-                        "bcrypt-pbkdf": "1.0.0",
-                        "dashdash": "1.14.0",
-                        "ecc-jsbn": "0.1.1",
-                        "getpass": "0.1.6",
-                        "jodid25519": "1.0.2",
-                        "jsbn": "0.1.0",
-                        "tweetnacl": "0.14.3"
-                      },
-                      "dependencies": {
-                        "asn1": {
-                          "version": "0.2.3",
-                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-                          "dev": true
-                        },
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                          "dev": true
-                        },
-                        "bcrypt-pbkdf": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
-                          "integrity": "sha1-PKdrhSQccXC/fZcD57mqdGMAQNQ=",
-                          "dev": true,
-                          "optional": true,
-                          "requires": {
-                            "tweetnacl": "0.14.3"
-                          }
-                        },
-                        "dashdash": {
-                          "version": "1.14.0",
-                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
-                          "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
-                          "dev": true,
-                          "requires": {
-                            "assert-plus": "1.0.0"
-                          }
-                        },
-                        "ecc-jsbn": {
-                          "version": "0.1.1",
-                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-                          "dev": true,
-                          "optional": true,
-                          "requires": {
-                            "jsbn": "0.1.0"
-                          }
-                        },
-                        "getpass": {
-                          "version": "0.1.6",
-                          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-                          "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
-                          "dev": true,
-                          "requires": {
-                            "assert-plus": "1.0.0"
-                          }
-                        },
-                        "jodid25519": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-                          "dev": true,
-                          "optional": true,
-                          "requires": {
-                            "jsbn": "0.1.0"
-                          }
-                        },
-                        "jsbn": {
-                          "version": "0.1.0",
-                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                          "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
-                          "dev": true,
-                          "optional": true
-                        },
-                        "tweetnacl": {
-                          "version": "0.14.3",
-                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
-                          "integrity": "sha1-PaOC9nDyXe1417PReSEZvKC3Ey0=",
-                          "dev": true,
-                          "optional": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "is-typedarray": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-                  "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-                  "dev": true
-                },
-                "isstream": {
-                  "version": "0.1.2",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                  "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-                  "dev": true
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                  "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-                  "dev": true
-                },
-                "mime-types": {
-                  "version": "2.1.12",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-                  "integrity": "sha1-FSuiVndwIN1GY/VMLnvCY4HnFyk=",
-                  "dev": true,
-                  "requires": {
-                    "mime-db": "1.24.0"
-                  },
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.24.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
-                      "integrity": "sha1-4tE/k58AFsbk6a0lqGUvEmxGfww=",
-                      "dev": true
-                    }
-                  }
-                },
-                "node-uuid": {
-                  "version": "1.4.7",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-                  "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
-                  "dev": true
-                },
-                "oauth-sign": {
-                  "version": "0.8.2",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-                  "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-                  "dev": true
-                },
-                "qs": {
-                  "version": "6.3.0",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
-                  "integrity": "sha1-9AOyZPI7wBIox0ExtAfxjV6l1EI=",
-                  "dev": true
-                },
-                "stringstream": {
-                  "version": "0.0.5",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                  "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-                  "dev": true
-                },
-                "tough-cookie": {
-                  "version": "2.3.2",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-                  "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-                  "dev": true,
-                  "requires": {
-                    "punycode": "1.4.1"
-                  },
-                  "dependencies": {
-                    "punycode": {
-                      "version": "1.4.1",
-                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-                      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-                      "dev": true
-                    }
-                  }
-                },
-                "tunnel-agent": {
-                  "version": "0.4.3",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-                  "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-                  "dev": true
-                }
-              }
-            },
-            "rimraf": {
-              "version": "2.5.4",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-              "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
-              "dev": true,
-              "requires": {
-                "glob": "7.1.1"
-              },
-              "dependencies": {
-                "glob": {
-                  "version": "7.1.1",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-                  "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-                  "dev": true,
-                  "requires": {
-                    "fs.realpath": "1.0.0",
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
-                  },
-                  "dependencies": {
-                    "fs.realpath": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-                      "dev": true
-                    },
-                    "inflight": {
-                      "version": "1.0.6",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-                      "dev": true,
-                      "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
-                      },
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                      "dev": true
-                    },
-                    "minimatch": {
-                      "version": "3.0.3",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                      "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-                      "dev": true,
-                      "requires": {
-                        "brace-expansion": "1.1.6"
-                      },
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.6",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                          "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-                          "dev": true,
-                          "requires": {
-                            "balanced-match": "0.4.2",
-                            "concat-map": "0.0.1"
-                          },
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.4.2",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-                              "dev": true
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.4.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                      "dev": true,
-                      "requires": {
-                        "wrappy": "1.0.2"
-                      },
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "semver": {
-              "version": "5.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-              "dev": true
-            },
-            "tar": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-              "dev": true,
-              "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.10",
-                "inherits": "2.0.3"
-              },
-              "dependencies": {
-                "block-stream": {
-                  "version": "0.0.9",
-                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-                  "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-                  "dev": true,
-                  "requires": {
-                    "inherits": "2.0.3"
-                  }
-                },
-                "fstream": {
-                  "version": "1.0.10",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-                  "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
-                  "dev": true,
-                  "requires": {
-                    "graceful-fs": "4.1.9",
-                    "inherits": "2.0.3",
-                    "mkdirp": "0.5.1",
-                    "rimraf": "2.5.4"
-                  },
-                  "dependencies": {
-                    "graceful-fs": {
-                      "version": "4.1.9",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-                      "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik=",
-                      "dev": true
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                  "dev": true
-                }
-              }
-            },
-            "tar-pack": {
-              "version": "3.3.0",
-              "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
-              "integrity": "sha1-MJMYFkGPVa/E0hd1r91nIM7kXa4=",
-              "dev": true,
-              "requires": {
-                "debug": "2.2.0",
-                "fstream": "1.0.10",
-                "fstream-ignore": "1.0.5",
-                "once": "1.3.3",
-                "readable-stream": "2.1.5",
-                "rimraf": "2.5.4",
-                "tar": "2.2.1",
-                "uid-number": "0.0.6"
-              },
-              "dependencies": {
-                "debug": {
-                  "version": "2.2.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                  "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-                  "dev": true,
-                  "requires": {
-                    "ms": "0.7.1"
-                  },
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.7.1",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-                      "dev": true
-                    }
-                  }
-                },
-                "fstream": {
-                  "version": "1.0.10",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-                  "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
-                  "dev": true,
-                  "requires": {
-                    "graceful-fs": "4.1.9",
-                    "inherits": "2.0.3",
-                    "mkdirp": "0.5.1",
-                    "rimraf": "2.5.4"
-                  },
-                  "dependencies": {
-                    "graceful-fs": {
-                      "version": "4.1.9",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-                      "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik=",
-                      "dev": true
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                      "dev": true
-                    }
-                  }
-                },
-                "fstream-ignore": {
-                  "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-                  "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-                  "dev": true,
-                  "requires": {
-                    "fstream": "1.0.10",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3"
-                  },
-                  "dependencies": {
-                    "inherits": {
-                      "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                      "dev": true
-                    },
-                    "minimatch": {
-                      "version": "3.0.3",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                      "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-                      "dev": true,
-                      "requires": {
-                        "brace-expansion": "1.1.6"
-                      },
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.6",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                          "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-                          "dev": true,
-                          "requires": {
-                            "balanced-match": "0.4.2",
-                            "concat-map": "0.0.1"
-                          },
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.4.2",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-                              "dev": true
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-                  "dev": true,
-                  "requires": {
-                    "wrappy": "1.0.2"
-                  },
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                      "dev": true
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "2.1.5",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-                  "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
-                  "dev": true,
-                  "requires": {
-                    "buffer-shims": "1.0.0",
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.3",
-                    "isarray": "1.0.0",
-                    "process-nextick-args": "1.0.7",
-                    "string_decoder": "0.10.31",
-                    "util-deprecate": "1.0.2"
-                  },
-                  "dependencies": {
-                    "buffer-shims": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-                      "dev": true
-                    },
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-                      "dev": true
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                      "dev": true
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                      "dev": true
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-                      "dev": true
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                      "dev": true
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-                      "dev": true
-                    }
-                  }
-                },
-                "uid-number": {
-                  "version": "0.0.6",
-                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-                  "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
-                  "dev": true
-                }
-              }
-            }
-          }
         }
       }
     },
     "sshpk": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-      "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
       "requires": {
         "asn1": "0.2.3",
@@ -4545,7 +3723,6 @@
         "dashdash": "1.14.1",
         "ecc-jsbn": "0.1.1",
         "getpass": "0.1.7",
-        "jodid25519": "1.0.2",
         "jsbn": "0.1.1",
         "tweetnacl": "0.14.5"
       },
@@ -4556,15 +3733,6 @@
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
-      }
-    },
-    "stream-combiner": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-      "dev": true,
-      "requires": {
-        "duplexer": "0.1.1"
       }
     },
     "string-width": {
@@ -4585,17 +3753,28 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.7.0",
-        "function-bind": "1.1.0"
+        "es-abstract": "1.8.2",
+        "function-bind": "1.1.1"
+      }
+    },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.8.2",
+        "function-bind": "1.1.1"
       }
     },
     "string_decoder": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.0.1"
+        "safe-buffer": "5.1.1"
       }
     },
     "stringifier": {
@@ -4604,7 +3783,7 @@
       "integrity": "sha1-3vGDQvaTPbDy2/yaoCF1tEjBeVk=",
       "dev": true,
       "requires": {
-        "core-js": "2.4.1",
+        "core-js": "2.5.1",
         "traverse": "0.6.6",
         "type-name": "2.0.2"
       }
@@ -4622,12 +3801,6 @@
       "requires": {
         "ansi-regex": "2.1.1"
       }
-    },
-    "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -4666,23 +3839,111 @@
         "chalk": "1.1.3",
         "lodash": "4.17.4",
         "slice-ansi": "0.0.4",
-        "string-width": "2.0.0"
+        "string-width": "2.1.1"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
         "string-width": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "3.0.1"
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
+      }
+    },
+    "tape": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.8.0.tgz",
+      "integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
+      "dev": true,
+      "requires": {
+        "deep-equal": "1.0.1",
+        "defined": "1.0.0",
+        "for-each": "0.3.2",
+        "function-bind": "1.1.1",
+        "glob": "7.1.2",
+        "has": "1.0.1",
+        "inherits": "2.0.3",
+        "minimist": "1.2.0",
+        "object-inspect": "1.3.0",
+        "resolve": "1.4.0",
+        "resumer": "0.0.0",
+        "string.prototype.trim": "1.1.2",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "tar": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "dev": true,
+      "requires": {
+        "block-stream": "0.0.9",
+        "fstream": "1.0.11",
+        "inherits": "2.0.3"
+      }
+    },
+    "tar-pack": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+      "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.8",
+        "fstream": "1.0.11",
+        "fstream-ignore": "1.0.5",
+        "once": "1.4.0",
+        "readable-stream": "2.3.3",
+        "rimraf": "2.6.1",
+        "tar": "2.2.1",
+        "uid-number": "0.0.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
           }
         }
       }
@@ -4704,7 +3965,7 @@
       "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.2.tgz",
       "integrity": "sha1-YcxHp2wavTGV8UUn+XjViulMUgQ=",
       "requires": {
-        "es5-ext": "0.10.21",
+        "es5-ext": "0.10.30",
         "next-tick": "1.0.0"
       }
     },
@@ -4784,16 +4045,50 @@
         "@types/marked": "0.0.28",
         "@types/minimatch": "2.0.29",
         "@types/shelljs": "0.7.4",
-        "fs-extra": "0.30.0",
+        "fs-extra": "3.0.1",
         "handlebars": "4.0.6",
         "highlight.js": "9.12.0",
         "lodash": "4.17.4",
         "marked": "0.3.6",
         "minimatch": "3.0.4",
-        "progress": "1.1.8",
-        "shelljs": "0.7.7",
+        "progress": "2.0.0",
+        "shelljs": "0.7.8",
         "typedoc-default-themes": "0.5.0",
         "typescript": "2.3.2"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+          "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "3.0.1",
+            "universalify": "0.1.1"
+          }
+        },
+        "jsonfile": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+          "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "progress": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+          "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+          "dev": true
+        }
       }
     },
     "typedoc-default-themes": {
@@ -4826,7 +4121,7 @@
       "integrity": "sha1-1Phd0oOOeiioVNnyVhbLxyo/Dg8=",
       "dev": true,
       "requires": {
-        "babylon": "6.17.1",
+        "babylon": "6.18.0",
         "commander": "2.9.0",
         "typhonjs-escomplex-module": "0.0.9",
         "typhonjs-escomplex-project": "0.0.9"
@@ -4870,20 +4165,20 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "2.8.27",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.27.tgz",
-      "integrity": "sha1-R3h/kSsPJC5bmENDvo416V9pTJw=",
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "optional": true,
       "requires": {
-        "source-map": "0.5.6",
+        "source-map": "0.5.7",
         "uglify-to-browserify": "1.0.2",
         "yargs": "3.10.0"
       },
       "dependencies": {
         "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "optional": true
         }
       }
@@ -4893,6 +4188,12 @@
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "optional": true
+    },
+    "uid-number": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+      "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+      "dev": true
     },
     "ultron": {
       "version": "1.0.2",
@@ -4922,6 +4223,12 @@
           "dev": true
         }
       }
+    },
+    "universalify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+      "dev": true
     },
     "user-home": {
       "version": "2.0.0",
@@ -4955,12 +4262,22 @@
       }
     },
     "verror": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "extsprintf": "1.0.2"
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
       }
     },
     "walkdir": {
@@ -4970,12 +4287,21 @@
       "dev": true
     },
     "which": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"
+      }
+    },
+    "wide-align": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2"
       }
     },
     "window-size": {
@@ -5027,12 +4353,6 @@
       "resolved": "https://registry.npmjs.org/xpipe/-/xpipe-1.0.5.tgz",
       "integrity": "sha1-jdi/Rfw/f1Xw4FS4ePQ6YmFNr98="
     },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
-    },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
@@ -5071,6 +4391,12 @@
         "nan": "2.3.5"
       },
       "dependencies": {
+        "bindings": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+          "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=",
+          "dev": true
+        },
         "nan": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz",

--- a/test/archivist/vaults/client.js
+++ b/test/archivist/vaults/client.js
@@ -28,7 +28,7 @@ function createState() {
 				msg: msg
 			});
 		},
-		emitToActors: function (actorIds, event, msg) {
+		emit: function (actorIds, event, msg) {
 			this._emitted.push({
 				actorIds: actorIds,
 				event: event,

--- a/test/modules/auth/index.js
+++ b/test/modules/auth/index.js
@@ -2,6 +2,7 @@ var assert = require('assert');
 
 describe('auth', function () {
 	var auth = require('lib/modules/auth');
+	var loggingService = require('lib/loggingService');
 	var libState = require('lib/state/state.js');
 	var State = libState.State;
 
@@ -18,12 +19,7 @@ describe('auth', function () {
 			isDevelopmentMode: function () { return true; }
 		};
 
-		var fakeLogger = {
-			error: function () {},
-			warning: function () {},
-			debug: function () {},
-			verbose: function () {}
-		};
+		var fakeLogger = loggingService.createLogCreator();
 
 		function FakeArchivist(/* state */) {
 			this.distribute = function (cb) { cb(); };

--- a/test/state.js
+++ b/test/state.js
@@ -33,7 +33,12 @@ var fakeMage = {
 	},
 	session: {
 		getActorAddresses: function (state, actorIds, cb) {
-			cb(null, actorIds.map(actorToAddress).filter(Boolean));
+			const response = {};
+			for (const actorId of actorIds) {
+				response[actorId] = actorToAddress(actorId);
+			}
+
+			cb(null, response);
 		}
 	},
 	core: {
@@ -666,76 +671,6 @@ describe('State class', function () {
 				});
 
 				done();
-			});
-		});
-
-		it('Results are cached', function (done) {
-			const actorIds = ['hello'];
-			const onlineAddresses = [{
-				actorId: 'hello'
-			}];
-
-			let called = false;
-
-			fakeMage.session = {
-				getActorAddresses: (state, lookup, cb) => {
-					if (called && lookup.length > 0) {
-						throw new Error('Result was not cached');
-					}
-
-					called = true;
-
-					cb(null, onlineAddresses);
-				}
-			};
-
-			var state = new State('abc', null, {
-				cacheTimeout: 1000
-			});
-
-			state.findActors(actorIds, function (error, found) {
-				assert.deepEqual(found.online, actorIds);
-
-				state.findActors(actorIds, function (error, found) {
-					assert.deepEqual(found.online, actorIds);
-					done();
-				});
-			});
-		});
-
-		it('Caches expire correctly', function (done) {
-			const actorIds = ['hello'];
-			const onlineAddresses = [{
-				actorId: 'hello'
-			}];
-
-			let called = false;
-
-			fakeMage.session = {
-				getActorAddresses: (state, lookup, cb) => {
-					if (called && lookup.length === 0) {
-						throw new Error('Result was cached');
-					}
-
-					called = true;
-
-					cb(null, onlineAddresses);
-				}
-			};
-
-			var state = new State('abc', null, {
-				cacheTimeout: 10
-			});
-
-			state.findActors(actorIds, function (error, found) {
-				assert.deepEqual(found.online, actorIds);
-
-				setTimeout(function () {
-					state.findActors(actorIds, function (error, found) {
-						assert.deepEqual(found.online, actorIds);
-						done();
-					});
-				}, 20);
 			});
 		});
 	});

--- a/test/state.js
+++ b/test/state.js
@@ -168,41 +168,6 @@ describe('State class', function () {
 		});
 	});
 
-	describe('timeout', function () {
-		let state;
-
-		beforeEach(() => state = new State(null));
-
-		it('timeouts can be set', function (done) {
-			mod.once('timeOut', () => done());
-			state.setTimeout(1);
-		});
-
-		it('timeouts can be set at instanciation', function (done) {
-			mod.once('timeOut', () => done());
-
-			new State(null, null, {
-				timeout: 1
-			});
-		});
-
-		it('timeouts can be cleared', function (done) {
-			function throwOnTimeout() {
-				throw new Error('Timeout triggered!');
-			}
-
-			mod.once('timeOut', throwOnTimeout);
-
-			state.setTimeout(1);
-			state.clearTimeout();
-
-			setTimeout(() => {
-				mod.removeListener('timeout', throwOnTimeout);
-				done();
-			}, 10);
-		});
-	});
-
 	describe('canAccess', function () {
 		function testCanAccess(stateAcl, canAccessAcl) {
 			const info = createStateWithSession(null, stateAcl);

--- a/test/state.js
+++ b/test/state.js
@@ -1,8 +1,12 @@
-var assert = require('assert');
-var mod = require('../lib/state/state.js');
-var State = mod.State;
+'use strict';
 
-function noop() {}
+const assert = require('assert');
+const loggingService = require('lib/loggingService');
+const mod = require('lib/state/state.js');
+
+const State = mod.State;
+
+let isDevelopmentMode = false;
 
 function FakeArchivist() {}
 
@@ -25,7 +29,7 @@ function actorToAddress(actorId) {
 
 var fakeMage = {
 	isDevelopmentMode: function () {
-		return false;
+		return isDevelopmentMode;
 	},
 	session: {
 		getActorAddresses: function (state, actorIds, cb) {
@@ -45,92 +49,445 @@ var fakeMage = {
 	}
 };
 
-var logger = {
-	verbose: noop,
-	warning: noop,
-	error: noop,
-	alert: noop
-};
-
-
 describe('State class', function () {
-	before(function () {
-		mod.initialize(fakeMage, logger, FakeArchivist);
-	});
+	const logger = loggingService.createLogCreator();
 
-	it('It should be constructable', function (done) {
-		var session = {
-			actorId: 'abc',
-			getData: function (/* key */) {
-				return undefined;
+	function createSession(actorId, aclData) {
+		return {
+			actorId,
+			getData: function (key) {
+				if (key !== 'acl') {
+					throw new Error(`session.getData received unknown key ${key}`);
+				}
+
+				return aclData;
 			}
 		};
+	}
 
-		var state = new State(null, session);
+	function createStateWithSession(actorId, acl) {
+		const session = createSession(actorId, acl);
+		const state = new State(null, session);
 
-		assert.strictEqual(state.session, session);
-		assert.strictEqual(state.actorId, 'abc');
+		return { session, state };
+	}
 
-		state = new State('def', session);
+	before(() => mod.initialize(fakeMage, logger, FakeArchivist));
 
-		assert.strictEqual(state.session, session);
-		assert.strictEqual(state.actorId, 'abc');
+	describe('instanciation', function () {
+		it('Without arguments', function () {
+			const state = new State();
 
-		done();
-	});
+			assert.equal(state.actorId, null);
+		});
+		it('With actorID as the first argument', function () {
+			const actorId = 'kwyjibo';
+			const state = new State(actorId);
 
-	it('Should bookkeep events', function (done) {
-		var state = new State('abc');
-
-		state.emit(null, 'test.1', { hello: 'world' });    // to self
-		state.emit('abc', 'test.2', { goodbye: 'world' }); // to self
-		state.emit('def', 'test.3', { three: 3 });         // to other user
-		state.emit(['def', 'ghi'], 'test.4', { four: 4 }); // to other users
-		state.emit('ghi', 'test.5', { five: 5 }, 'en');    // to other user
-		state.emit('ghi', 'test.6', { six: 6 }, 'nl');     // to other user in wrong language (should be dropped)
-		state.emit('jkl', 'test.7', { seven: 7 });         // to other user
-
-		state.close(function (error, output) {
-			assert.ifError(error);
-
-			assert.deepEqual(output.myEvents, [
-				'["test.1",{"hello":"world"}]',
-				'["test.2",{"goodbye":"world"}]'
-			]);
-
-			assert.deepEqual(fakeMage.core.msgServer.sent, [
-				{
-					addrName: 'addr:def',
-					clusterId: 'cluster:def',
-					payload: '[["test.3",{"three":3}],["test.4",{"four":4}]]'
-				},
-				{
-					addrName: 'addr:ghi',
-					clusterId: 'cluster:ghi',
-					payload: '[["test.4",{"four":4}],["test.5",{"five":5}]]'
-				},
-				{
-					addrName: 'addr:jkl',
-					clusterId: 'cluster:jkl',
-					payload: '[["test.7",{"seven":7}]]'
-				}
-			]);
-
-			done();
+			assert.equal(state.actorId, actorId);
 		});
 	});
 
-	it('Should find actors', function (done) {
-		var state = new State('abc');
-		state.findActors(['def', 'foo', 'offline', 'bar'], function (error, found) {
-			assert.ifError(error);
+	describe('session register/unregister', function () {
+		afterEach(() => isDevelopmentMode = false);
 
-			assert.deepEqual(found, {
-				online: ['def', 'foo', 'bar'],
-				offline: ['offline']
+		it('session is set on the state object', function () {
+			const state = new State();
+			const session = createSession('abc');
+
+			state.registerSession(session);
+
+			assert.deepEqual(state.session, session);
+		});
+
+		it('setting the session resets the state\'s actorId', function () {
+			const state = new State();
+			const actorId = 'abc';
+			const session = createSession(actorId);
+
+			state.registerSession(session);
+
+			assert.equal(state.actorId, actorId);
+		});
+
+		it('session can be passed as an argument upon instanciating a new state', function () {
+			const actorId = 'abc';
+			const info = createStateWithSession(actorId);
+			const state = info.state;
+			const session = info.session;
+
+			assert.deepEqual(state.session, session);
+			assert.strictEqual(state.actorId, actorId);
+		});
+
+		it('session acl data is copied onto the state', function () {
+			const acl = ['abc', 'youandme'];
+			const info = createStateWithSession('abc', acl);
+			const state = info.state;
+
+			assert.deepEqual(state.acl, acl);
+		});
+
+		it('If a session has no ACL, state.acl is an empty array', function () {
+			const acl = false;
+			const info = createStateWithSession('abc', acl);
+			const state = info.state;
+
+			assert.deepEqual(state.acl, []);
+		});
+
+		it('wildcard ACL (*) is pushed automatically onto the state in devMode (if not already present)', function () {
+			isDevelopmentMode = true;
+
+			const acl = ['abc', 'youandme'];
+			const info = createStateWithSession('abc', acl);
+			const state = info.state;
+
+			assert.deepEqual(state.acl, ['*', 'abc', 'youandme']);
+		});
+
+		it('Unregistering the session resets related attributes on the state object', function () {
+			const acl = ['*', 'abc', 'youandme'];
+			const info = createStateWithSession('abc', acl);
+			const state = info.state;
+
+			state.unregisterSession();
+
+			assert.equal(state.session, undefined);
+			assert.equal(state.actorId, undefined);
+			assert.deepEqual(state.acl, []);
+		});
+	});
+
+	describe('timeout', function () {
+		let state;
+
+		beforeEach(() => state = new State(null));
+
+		it('timeouts can be set', function (done) {
+			mod.once('timeOut', () => done());
+			state.setTimeout(1);
+		});
+
+		it('timeouts can be cleared', function (done) {
+			function throwOnTimeout() {
+				throw new Error('Timeout triggered!');
+			}
+
+			mod.once('timeOut', throwOnTimeout);
+
+			state.setTimeout(1);
+			state.clearTimeout();
+
+			setTimeout(() => {
+				mod.removeListener('timeout', throwOnTimeout);
+				done();
+			}, 10);
+		});
+	});
+
+	describe('canAccess', function () {
+		function testCanAccess(stateAcl, canAccessAcl) {
+			const info = createStateWithSession(null, stateAcl);
+
+			return info.state.canAccess(canAccessAcl);
+		}
+
+		function assertCanAccess(stateAcl, canAccessAcl, expected) {
+			assert.strictEqual(testCanAccess(stateAcl, canAccessAcl), expected);
+		}
+
+		it('returns true if the State\'s ACL contains a wildcard (*)', function () {
+			assertCanAccess(['*'], undefined, true);
+		});
+
+		it('returns false if no ACL definition was passed as argument', function () {
+			assertCanAccess(['user'], undefined, false);
+		});
+
+		it('returns false if ACL is not an array', function () {
+			assertCanAccess(['user'], 'not an array', false);
+		});
+
+		it('returns false if the ACL array is empty', function () {
+			assertCanAccess(['user'], [], false);
+		});
+
+		it('returns true if the ACL contains a wildcard (*)', function () {
+			assertCanAccess([], ['*'], true);
+		});
+
+		it('returns true if any of the value in the arguments are found in the state ACL', function () {
+			assertCanAccess(['admin', 'user', 'whatever'], ['user'], true);
+		});
+
+		it('returns false if nothing is matched', function () {
+			assertCanAccess(['user'], ['admin'], false);
+		});
+	});
+
+	describe('description', function () {
+		it('default desctiption is returned', function () {
+			const info = createStateWithSession();
+			assert.equal(info.state.getDescription(), 'no description');
+		});
+
+		it('set description is returned', function () {
+			const info = createStateWithSession();
+			const state = info.state;
+			const description = 'oh hai';
+			state.setDescription(description);
+
+			assert.equal(state.getDescription(), description);
+		});
+	});
+
+	describe('closing (call stack, details)', function () {
+		it('Calling getClosingDetails before setClosing throws', function () {
+			const info = createStateWithSession();
+
+			assert.throws(() => info.state.getClosingDetails());
+		});
+
+		it('Calling getClosingDetails after setClosing works', function () {
+			const info = createStateWithSession();
+			const state  = info.state;
+
+			state.setClosing();
+
+			assert.equal(state.closing, true);
+
+			const details = state.getClosingDetails();
+
+			assert.equal(details.description, state.getDescription());
+			assert(details.stack);
+		});
+
+		it('Calling setClosing more than once throws an error', function () {
+			const info = createStateWithSession();
+			const state = info.state;
+
+			state.setClosing();
+
+			assert.throws(() => state.setClosing());
+		});
+
+		it('Accessing state attributes after closing throws', function () {
+			const info = createStateWithSession();
+			const state = info.state;
+
+			state.close();
+
+			assert.throws(() => state.errorCode);
+		});
+
+		it('Setting state attributes after closing throws', function () {
+			const info = createStateWithSession();
+			const state = info.state;
+
+			state.close();
+
+			assert.throws(() => state.errorCode = 'this will die');
+		});
+	});
+
+	describe('distribute/distributeEvents', function () {
+		const actorId = 'it-is-me-mario';
+
+		let state;
+		beforeEach(() => state = new State(actorId));
+
+		it('distributeEvents reallocates my events to other events, and emits them through msgStream', function (done) {
+			state.emit('random', 'first', '123');
+			state.emit(actorId, 'second', '456');
+
+			state.emitEvents = function (events, callback) {
+				assert.deepEqual(state.myEvents, []);
+				assert.deepEqual(state.otherEvents, {
+					random: [{
+						evt: '["first","123"]',
+						alwaysEmit: undefined
+					}],
+					[actorId]: [{
+						evt: '["second","456"]',
+						alwaysEmit: undefined
+					}]
+				});
+
+				callback();
+			};
+
+			state.distributeEvents(done);
+		});
+
+		it('distribute will not distribute events if archivist fails to commit changes', function () {
+			const message = 'bai bai!';
+			const error = new Error(message);
+
+			state.archivist.distribute = (callback) => callback(error);
+			state.distributeEvents = () => { throw new Error('distributeEvents was called'); };
+
+			state.distribute(function (returnedError) {
+				assert.equal(returnedError.message, message);
 			});
+		});
 
-			done();
+		it('distribute will distribute events if archivist succeeds to commit changes', function (done) {
+			state.archivist.distribute = (callback) => callback();
+			state.distributeEvents = done();
+			state.distribute();
+		});
+	});
+
+	describe('error', function () {
+		let state;
+		beforeEach(() => state = new State());
+
+		it('Error code is extracted if code is an error with a code attribute', function () {
+			const error = new Error('Whoops');
+			const code = 'yay';
+			error.code = code;
+
+			state.error(error);
+
+			assert.equal(state.errorCode, `"${code}"`);
+		});
+
+		it('Error message is extracted if code is an error without a code attribute', function () {
+			const error = new Error('Whoops');
+			state.error(error);
+			assert.equal(state.errorCode, `"${error.message}"`);
+		});
+
+		it('"server" is returned instead of objects and arrays', function () {
+			state.error({});
+			assert.equal(state.errorCode, '"server"');
+		});
+
+		it('code values are stringified', function () {
+			state.error(1);
+			assert.equal(state.errorCode, '"1"');
+		});
+
+		it('optional callback is called', function (done) {
+			const code = 'yay';
+
+			state.error(code, 'details', function () {
+				assert.equal(state.errorCode, `"${code}"`);
+				done();
+			});
+		});
+	});
+
+	describe('respond', function () {
+		let state;
+		beforeEach(() => state = new State());
+
+		it('Data is stringified by default', function () {
+			state.respond({ hello: 'world' });
+			assert.equal(state.response, '{"hello":"world"}');
+		});
+
+		it('Data is not stringified if the second argument is set to true', function () {
+			const data = 'this is a raw string';
+
+			state.respond(data, true);
+			assert.equal(state.response, data);
+		});
+	});
+
+	describe('close (and return data)', function () {
+		it('Should bookkeep events', function (done) {
+			var state = new State('abc');
+
+			state.emit(null, 'test.1', { hello: 'world' });    // to self
+			state.emit('abc', 'test.2', { goodbye: 'world' }); // to self
+			state.emit('def', 'test.3', { three: 3 });         // to other user
+			state.emit(['def', 'ghi'], 'test.4', { four: 4 }); // to other users
+			state.emit('jkl', 'test.7', { seven: 7 });         // to other user
+
+			state.close(function (error, output) {
+				assert.ifError(error);
+
+				assert.deepEqual(output.myEvents, [
+					'["test.1",{"hello":"world"}]',
+					'["test.2",{"goodbye":"world"}]'
+				]);
+
+				assert.deepEqual(fakeMage.core.msgServer.sent, [
+					{
+						addrName: 'addr:def',
+						clusterId: 'cluster:def',
+						payload: '[["test.3",{"three":3}],["test.4",{"four":4}]]'
+					},
+					{
+						addrName: 'addr:ghi',
+						clusterId: 'cluster:ghi',
+						payload: '[["test.4",{"four":4}]]'
+					},
+					{
+						addrName: 'addr:jkl',
+						clusterId: 'cluster:jkl',
+						payload: '[["test.7",{"seven":7}]]'
+					}
+				]);
+
+				done();
+			});
+		});
+
+		it('When alwaysEmit is set to true, emit/broadcast even when an error occurs', function (done) {
+			var state = new State('stroganoff');
+			var emit = { alwaysEmit: true };
+
+			// Clear the queue of sent messages
+			fakeMage.core.msgServer.sent = [];
+
+			state.emit(null, 'test.1', { hello: 'world' }); // Should not be emitted
+			state.emit(null, 'test.2', { goodbye: 'world' }, emit);
+			state.emit('shanata', 'test.3', { three: 3 });  // Should not be emitted
+			state.emit('shanata', 'test.4', { four: 4 }, emit);
+			state.broadcast('never.emit', { hola: 5 });  // Should not be emitted
+			state.broadcast('always.emit', { ohayou: 6 }, emit);
+
+			state.errorCode = 'brokendit';
+
+			state.close(function (error, output) {
+				assert.ifError(error);
+
+				assert.deepEqual(output.myEvents, [
+					'["test.2",{"goodbye":"world"}]'
+				]);
+
+				assert.deepEqual(fakeMage.core.msgServer.sent, [
+					{
+						payload: '[["always.emit",{"ohayou":6}]]'
+					},
+					{
+						addrName: 'addr:shanata',
+						clusterId: 'cluster:shanata',
+						payload: '[["test.4",{"four":4}]]'
+					}
+				]);
+
+				done();
+			});
+		});
+	});
+
+	describe('findActors', function () {
+		it('Should find actors', function (done) {
+			var state = new State('abc');
+			state.findActors(['def', 'foo', 'offline', 'bar'], function (error, found) {
+				assert.ifError(error);
+
+				assert.deepEqual(found, {
+					online: ['def', 'foo', 'bar'],
+					offline: ['offline']
+				});
+
+				done();
+			});
 		});
 	});
 });

--- a/test/state.js
+++ b/test/state.js
@@ -531,6 +531,20 @@ describe('State class', function () {
 				done();
 			});
 		});
+
+		it('Error code is returned on close', function (done) {
+			const error = new Error('Whoops');
+			state.error(error);
+			state.close((_, response) => {
+				assert.deepEqual(response, {
+					response: undefined,
+					errorCode: `"${error.message}"`,
+					myEvents: undefined
+				});
+
+				done();
+			});
+		});
 	});
 
 	describe('respond', function () {
@@ -547,6 +561,19 @@ describe('State class', function () {
 
 			state.respond(data, true);
 			assert.equal(state.response, data);
+		});
+
+		it('Response data is returned on close', function (done) {
+			state.respond({ hello: 'world' });
+			state.close((error, response) => {
+				assert.deepEqual(response, {
+					response: '{"hello":"world"}',
+					errorCode: undefined,
+					myEvents: undefined
+				});
+
+				done();
+			});
 		});
 	});
 


### PR DESCRIPTION
### Behavior changes

  - `state.setTimeout`, if ever used on a user command's state, would leave the client connection hanging forever, if triggered. Since this feature didn't appear to make any sense on `state` in the first place, this feature was re-implemented in the command center instead (see below) 
  - Do not log a warning if we call `emitEvents` without broadcast data
     regardless of whether `msgServer` is present or not
  - Do not log a warning if we call emitEvents without emit data
     regardless of whether the `session` module is present or not
  - Log an error on state close if either of those modules are required, or
    if any other errors are returned

### API changes
  
  - State instanciation now takes an options argument (see IStateOptions)
  - Removed emitToActors (was already deprecated)
  - Removed: state.setTimeout/clearTimeout
  - Removed the 'language' option on emit
  - `emit/broadcast` new `alwaysEmit` option: emit even on failure (fixes #91)
  - New public method `distribute()`: distribute all archivist mutations and events
  - New public method `distributeEvents()`: distribute only events

### Bugfixes

  - `broadcast`: do not send on error (unless alwaysEmit is set) (fixes #91)
  - `emit to self`: do not send on error (unless alwaysEmit is set) (fixes #91)
  - state.emit: do not de-duplicate emitting of the same event to the same actorId multiple times
  
### Internal refactoring
  
  - The state's internal address cache was useless, since archivist was caching values behind that anyway. 
  - StateAccessError -> StateError
  - state.addresse -> state.addressesCache
  - Unit tests: 100% code coverage
  - Updated type definition file

### Other

  - commandCenter: refactoring of the user command execution flow so that all user commands
    would be executed as promises. This helped to simplify the implementation of the `timeout` feature
    (see next point), but also provides a bit more safety, since now early assertions (not executed in an
    asynchronous context) will also be caught 
  - `usercommand.timeout`: configurable user command field allowing to terminate the execution of a
    user command based on a timeout value. Not set by default (so the execution will never time out)
  