### PR TITLE
invalid session and unstable connections

### DIFF
--- a/lib/serviceDiscovery/engines/zookeeper/index.js
+++ b/lib/serviceDiscovery/engines/zookeeper/index.js
@@ -5,7 +5,7 @@ var os = require('os');
 var mage = require('../../../mage');
 var requirePeer = require('codependency').get('mage');
 var zooKeeper = requirePeer('node-zookeeper-client');
-var logger = mage.core.logger.context('zooKeeper');
+var logger = mage.core.logger.context('zookeeper');
 
 var CONNECT_TIMEOUT = 5 * 1000;
 
@@ -107,7 +107,11 @@ function createZooKeeperClient(options) {
 function ZooKeeperService(name, type, options) {
 	this.name = name;
 	this.type = type;
-	this.client = createZooKeeperClient(options);
+	this.options = options;
+
+	this.closed = false;
+	this.announcing = false;
+	this.discovering = false;
 
 	// this is the base path we will use to announce this service
 	this.baseAnnouncePath = ['/mage', this.name, this.type].join('/');
@@ -118,16 +122,74 @@ function ZooKeeperService(name, type, options) {
 	// node data is stored apart
 	this.services = {};
 
-	// connect
+	this.connectTimer = null;
+	this.clearCredentialsTimer = null;
+
+	// Initial setup
+	this.reset();
+}
+
+util.inherits(ZooKeeperService, Service);
+
+
+ZooKeeperService.prototype.reset = function () {
+	const { options } = this;
+
+	this.client = createZooKeeperClient(options);
+
+	// After reading the code below, you might feel a bit
+	// disgusted; this is perfectly normal, but currently
+	// unavoidable.
+	//
+	// The client library we are currently using will simply
+	// cycle forever on all zookeeper node if the remote server
+	// respond with an invalid session error. While this possibly make
+	// sense for larger deployments, it also means that restarting a single
+	// ZooKeeper node would mean needing to restart the MAGE cluster.
+	//
+	// To solve this, we simply replace the client if we cannot achiever
+	// a connection for too long.
+	//
+	// See: https://github.com/mage/mage/issues/108
+	this.client.on('connected', function () {
+		if (this.connectTimer) {
+			clearTimeout(this.connectTimer);
+		}
+
+		if (this.clearCredentialsTimer) {
+			clearTimeout(this.clearCredentialsTimer);
+		}
+	});
+
+	this.client.on('disconnected', () => {
+		this.clearCredentialsTimer = setTimeout(() => {
+			var state = this.client.getState();
+
+			if (state !== zooKeeper.State.SYNC_CONNECTED) {
+				logger.verbose('Connection appears unstable, re-setting');
+				this.client.close();
+				this.reset();
+			}
+		}, CONNECT_TIMEOUT);
+	});
+
+	if (this.closed) {
+		return;
+	}
 
 	logger.verbose('ZooKeeper client connecting to', options.hosts);
-
-	var that = this;
-
 	this.client.connect();
 
-	this.connectTimer = setTimeout(function () {
-		var state = that.client.getState();
+	if (this.discovering !== false) {
+		this.discover();
+	}
+
+	if (this.announcing !== false) {
+		this.announcing(this.announcing[0], this.announcing[1], () => false);
+	}
+
+	this.connectTimer = setTimeout(() => {
+		var state = this.client.getState();
 
 		if (state !== zooKeeper.State.SYNC_CONNECTED) {
 			logger.alert.data('connection-options', options).log(
@@ -135,13 +197,8 @@ function ZooKeeperService(name, type, options) {
 				'Please inspect your configuration.'
 			);
 		}
-
-		that.connectTimer = null;
 	}, CONNECT_TIMEOUT);
-}
-
-util.inherits(ZooKeeperService, Service);
-
+};
 
 /**
  * Announce our service to the world.
@@ -158,6 +215,8 @@ util.inherits(ZooKeeperService, Service);
  */
 ZooKeeperService.prototype.announce = function (port, metadata, cb) {
 	var that = this;
+
+	this.announcing = [port, metadata];
 
 	// enrich metadata with some extra stuff from us
 	metadata = {
@@ -328,6 +387,8 @@ ZooKeeperService.prototype.discover = function () {
 
 	logger.debug('Discovering network');
 
+	this.discovering = true;
+
 	function onWatch(event) {
 		that.onWatchEvent(event);
 	}
@@ -357,6 +418,10 @@ ZooKeeperService.prototype.close = function (cb) {
 	if (state === zooKeeper.State.SYNC_CONNECTED) {
 		this.client.close();
 	}
+
+	this.closed = true;
+	this.discovering = false;
+	this.announcing = false;
 
 	setImmediate(cb);
 };


### PR DESCRIPTION
In particular, this solves an issue where the underlying client
connection would simply rotate over the list of server forever
if the client has an invalid session. This causes issue
when running, for instance, a single ZK node, and restarting
it while a MAGE cluster is connected to it (all nodes end up
spamming the ZooKeeper instance once it comes back).

Fixes #108