### PR TITLE
details on vault setup errors, create migrates

### DIFF
--- a/lib/archivist/configuration.js
+++ b/lib/archivist/configuration.js
@@ -132,6 +132,14 @@ function createVault(vaultName, vaultType, vaultConfig, cb) {
 
 		vault.setup(vaultConfig || {}, function (error) {
 			if (error) {
+				logger.alert
+					.details('Early errors may mean one of the following:')
+					.details('  1. The remote server is down or inaccessible')
+					.details('  2. You need to run `npm run archivist:create` to create')
+					.details('     and configure storage for your vault backend')
+					.details('See error data for more details.')
+					.log(`Failed to set up vault ${vaultName}`);
+
 				return cb(error);
 			}
 

--- a/lib/tasks/archivist-create.js
+++ b/lib/tasks/archivist-create.js
@@ -1,14 +1,11 @@
 var async = require('async');
+var migrate = require('./migrate');
 
 
 exports.setup = function (mage, options, cb) {
 	async.series([
-		function (callback) {
-			mage.core.loggingService.setup(callback);
-		},
-		function (callback) {
-			mage.core.archivist.setup(callback);
-		}
+		(callback) => mage.core.loggingService.setup(callback),
+		(callback) => mage.core.archivist.setup(callback)
 	], cb);
 };
 
@@ -37,7 +34,7 @@ exports.start = function (mage, options, cb) {
 			return cb(error);
 		}
 
-		cb(null, { shutdown: true });
+		migrate.start(mage, options, cb);
 	});
 };
 

--- a/lib/tasks/archivist-migrate.js
+++ b/lib/tasks/archivist-migrate.js
@@ -3,12 +3,8 @@ var async = require('async');
 
 exports.setup = function (mage, options, cb) {
 	async.series([
-		function (callback) {
-			mage.core.loggingService.setup(callback);
-		},
-		function (callback) {
-			mage.core.archivist.setup(callback);
-		}
+		(callback) => mage.core.loggingService.setup(callback),
+		(callback) => mage.core.archivist.setup(callback)
 	], cb);
 };
 


### PR DESCRIPTION
Error log will hint the user that they need to run `archivist:create`
to setup up the storage.

`archivist:create` now implies `archivist:migrate`.

Fixes #104 cc @tatsujinichi