### PR TITLE
Update RELEASE_GUIDE.md

### DIFF
--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -45,7 +45,7 @@ To make a patch-release, we cherry-pick commits from master into a temporary bra
 5. Run: `git push upstream 1.2.4` (replace `1.2.4` by the new version tag)
 6. Write up the release notes at the new tag on https://github.com/mage/mage/releases/new
 7. Run: `npm publish`
-8. Remove your temporary release branch: `git checkout master && git branch -d release`
+8. Remove your temporary release branch: `git checkout master; git branch -d release`
 
 ## After publishing the release
 

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -10,15 +10,42 @@ We apply a semver-ish versioning scheme, using the following logic:
 
 ## How to release
 
-1. Ensure your shell is in the `master` branch
-2. Ensure you are up-to-date: `git pull upstream master` (where "upstream" references https://github.com/mage/mage)
-3. Determine whether this release is a major, minor or patch release
-4. Run: `npm version major`, `npm version minor` or `npm version patch`. This will have:
+In all the `git` shell commands below, `upstream` references the repository at https://github.com/mage/mage.
+
+1. Ensure your shell is in the `master` branch: `git checkout master`
+2. Ensure you are up-to-date: `git pull upstream master`
+3. Continue below
+
+### A) Minor or Patch release based on master
+
+If this is a patch release or if you are making a minor release that is equal to the current state of the `master` branch, you can release the `master`-branch directly.
+
+1. Compare changes with the previous release: `git log master...1.2.3` (replace `1.2.3` by the previous version tag)
+2. Run: `npm version minor` or `npm version patch`. This will have:
     1. Updated the version in package.json
     2. Regenerated documentation
     3. Committed (git)
     4. Tagged (git)
-5. Run: `git push upstream master --tags` (where "upstream" references https://github.com/mage/mage)
+3. Run: `git push upstream master --tags`
+4. Write up the release notes at the new tag on https://github.com/mage/mage/releases/new
+5. Run: `npm publish`
+
+### B) Patch release based on a previous release
+
+If we have already merged minor-level commits into `master` that should not land in this patch release, we can cherry-pick our way to a patch release.
+
+1. Create a release branch: `git checkout -b release 1.2.3` (replace `1.2.3` by the previous version tag)
+2. Compare changes with `master`: `git log master...release --cherry-pick` (this is where we will pick commits from)
+3. Pick all commits you wish to include: `git cherry-pick COMMITHASH` (replace `COMMITHASH`)
+4. Run: `npm version patch`. This will have:
+    1. Updated the version in package.json
+    2. Regenerated documentation
+    3. Committed (git)
+    4. Tagged (git)
+5. Run: `git push upstream --tags`
 6. Write up the release notes at the new tag on https://github.com/mage/mage/releases/new
 7. Run: `npm publish`
-8. Spread the news on the relevant communication channels
+
+## After publishing the release
+
+Now spread the news on the relevant communication channels.

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -16,12 +16,12 @@ In all the `git` shell commands below, `upstream` references the repository at h
 2. Ensure you are up-to-date: `git pull upstream master`
 3. Continue below
 
-### A) Minor or Patch release based on master
+### A) Minor release
 
-If this is a patch release or if you are making a minor release that is equal to the current state of the `master` branch, you can release the `master`-branch directly.
+If you are making a minor release that is equal to the current state of the `master` branch, you can release the `master`-branch directly.
 
 1. Compare changes with the previous release: `git log master...1.2.3` (replace `1.2.3` by the previous version tag)
-2. Run: `npm version minor` or `npm version patch`. This will have:
+2. Run: `npm version minor`. This will have:
     1. Updated the version in package.json
     2. Regenerated documentation
     3. Committed (git)
@@ -30,11 +30,11 @@ If this is a patch release or if you are making a minor release that is equal to
 4. Write up the release notes at the new tag on https://github.com/mage/mage/releases/new
 5. Run: `npm publish`
 
-### B) Patch release based on a previous release
+### B) Patch release
 
-If we have already merged minor-level commits into `master` that should not land in this patch release, we can cherry-pick our way to a patch release.
+To make a patch-release, we cherry-pick commits from master into a temporary branch that will become our release.
 
-1. Create a release branch: `git checkout -b release 1.2.3` (replace `1.2.3` by the previous version tag)
+1. Create a temporary release branch: `git checkout -b release 1.2.3` (replace `1.2.3` by the previous version that you base this patch release on)
 2. Compare changes with `master`: `git log master...release --cherry-pick` (this is where we will pick commits from)
 3. Pick all commits you wish to include: `git cherry-pick COMMITHASH` (replace `COMMITHASH`)
 4. Run: `npm version patch`. This will have:
@@ -42,9 +42,10 @@ If we have already merged minor-level commits into `master` that should not land
     2. Regenerated documentation
     3. Committed (git)
     4. Tagged (git)
-5. Run: `git push upstream --tags`
+5. Run: `git push upstream 1.2.4` (replace `1.2.4` by the new version tag)
 6. Write up the release notes at the new tag on https://github.com/mage/mage/releases/new
 7. Run: `npm publish`
+8. Remove your temporary release branch: `git checkout master && git branch -d release`
 
 ## After publishing the release
 


### PR DESCRIPTION
I've added a how-to for cherry-picking a patch-release. I've not fully tested it yet, to avoid noise on the GitHub repo. Let's start by picking this apart :)

I can imagine there may be some superior (and/or simpler) git commands that can be used to visualize changes between branches that someone may be aware of. I would love to hear it if that's the case :)