### PR TITLE
encoder: throw error if type is not a string

### DIFF
--- a/lib/archivist/encoders.js
+++ b/lib/archivist/encoders.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // encoding types:
 //   live (native JS objects, does not include Buffer instances)
 //   utf8 (string)
@@ -13,6 +15,15 @@
 var commonEncoders = {};
 var mediaTypeEncoders = {};
 
+class ArchivistEncodingError extends Error {
+	constructor(message, from, to, data) {
+		super(message);
+		this.name = 'ArchivistEncodingError';
+		this.from = from;
+		this.to = to;
+		this.data = data;
+	}
+}
 
 exports.registerCommonEncoder = function (fromEncoding, toEncoding, fn) {
 	if (!fn) {
@@ -127,32 +138,49 @@ function getEncoder(mediaType, fromEncoding, toEncoding) {
 	};
 }
 
+function assertString(fromEncoding, toEncoding, data) {
+	if (typeof data !== 'string') {
+		throw new ArchivistEncodingError('Invalid data type', fromEncoding, toEncoding, data);
+	}
+}
+
+function assertBuffer(fromEncoding, toEncoding, data) {
+	if (Buffer.isBuffer(data) === false) {
+		throw new ArchivistEncodingError('Invalid data type', fromEncoding, toEncoding, data);
+	}
+};
 
 // add built-in conversions
 
 var register = exports.registerCommonEncoder;
 
-register('utf8',   'buffer', function (data) {
+register('utf8', 'buffer', function (data) {
+	assertString('utf8', 'buffer', data);
 	return new Buffer(data);
 });
 
 register('base64', 'buffer', function (data) {
+	assertString('base64', 'buffer', data);
 	return new Buffer(data, 'base64');
 });
 
 register('buffer', 'base64', function (data) {
+	assertBuffer('buffer', 'base64', data);
 	return data.toString('base64');
 });
 
 register('buffer', 'utf8', function (data) {
+	assertBuffer('buffer', 'utf8', data);
 	return data.toString('utf8');
 });
 
 register('utf8', 'base64', function (data) {
+	assertString('utf8', 'base64', data);
 	return (new Buffer(data, 'utf8')).toString('base64');
 });
 
 register('base64', 'utf8', function (data) {
+	assertBuffer('base64', 'utf8', data);
 	return (new Buffer(data, 'base64')).toString('utf8');
 });
 


### PR DESCRIPTION
The default encoders will now throw an error if the submitted
type is not a string or a Buffer. This should avoid situations
like this:

```javascript
state.archivist.set('foobar', {}, [], 'application/json', 'utf8');
```

Which would end up always returning an empty string, because:

  - new Buffer([]) is an empty string
  - [].toString() is also an empty string