### PR TITLE
archivist: scan and per-query options

### DIFF
--- a/docs-sources/includes/_Archivist.md
+++ b/docs-sources/includes/_Archivist.md
@@ -523,27 +523,27 @@ exports.getItemsForUser = function (state, userId, callback) {
   var topic = 'item';
   var partialIndex = { userId: userId };
 
-  state.archivist.list(topic, partialIndex, function (error, indexes) {
-    if (error) {
-      return callback(error);
-    }
-
-    var queries = indexes.map(function (index) {
-      return { topic: topic, index: index };
-    });
-
-    state.archivist.mget(queries, callback);
-  });
+  state.archivist.scan(topic, partialIndex, callback);
 };
 ```
 
-There are a few ways by which you can split and filter the data
-stored in your topics.
+With certain APIs you can provide only a portion of an index and search for
+all indexes who have the same value for that option. These indexes are referred
+to as *partial indexes*.
 
-In this example, we have an `item` topic with an index of two fields: `userId` and `itemId`.
-When a topic index has more than one field, we can use the `partialKey` on a `state.archivist.list`
-call to filter the list of keys to return. In the sample code here, we use this
-feature to return all items' full keys for a given user.
+There are a few ways by which you can split and filter the data
+stored in your topics:
+
+  1. You can use [archivist.list](https://mage.github.io/mage/api/classes/archivist.html#list) to list
+     all the indexes matching a given partial index
+  2. You can use [archivist.mget](https://mage.github.io/mage/api/classes/archivist.html#mget) to fetch
+     multiple indexes at once
+  3. You can use [archivist.scan](https://mage.github.io/mage/api/classes/archivist.html#list), which combines
+     both operations mentioned above into one
+
+You will generally want to use `scan` for most of your operations, but in some cases, you will find
+that manually fetching the list of indexes using `list` and applying your own custom filtering before
+calling `mget` will give you a better result.
 
 ## Limiting access
 

--- a/docs-sources/includes/_Archivist.md
+++ b/docs-sources/includes/_Archivist.md
@@ -538,7 +538,7 @@ stored in your topics:
      all the indexes matching a given partial index
   2. You can use [archivist.mget](https://mage.github.io/mage/api/classes/archivist.html#mget) to fetch
      multiple indexes at once
-  3. You can use [archivist.scan](https://mage.github.io/mage/api/classes/archivist.html#list), which combines
+  3. You can use [archivist.scan](https://mage.github.io/mage/api/classes/archivist.html#scan), which combines
      both operations mentioned above into one
 
 You will generally want to use `scan` for most of your operations, but in some cases, you will find

--- a/lib/archivist/index.js
+++ b/lib/archivist/index.js
@@ -511,7 +511,7 @@ Archivist.prototype.getValue = function (topic, index, options, cb) {
 
 // multiget helper function
 
-function mgetAggregate(queries, retriever, cb) {
+function mgetAggregate(queries, options, retriever, cb) {
 	// queries: [{ topic: 'foo', index: { id: 1 } }, { topic: 'bar', index: { id: 'abc' } }]
 	//   OR:
 	// queries: { uniqueID: { topic: 'foo', index: { id: 1 } }, uniqueID2: { etc }
@@ -526,7 +526,15 @@ function mgetAggregate(queries, retriever, cb) {
 		async.forEachSeries(
 			Object.keys(queries),
 			function (queryId, callback) {
-				retriever(queries[queryId], function (error, data) {
+				const query = queries[queryId];
+
+				if (!query.options) {
+					query.options = {};
+				}
+
+				query.options = Object.assign({}, options, query.options);
+
+				retriever(query, function (error, data) {
 					if (error) {
 						callback(error);
 					} else {
@@ -563,13 +571,17 @@ Archivist.prototype.mget = function (queries, options, cb) {
 		options = undefined;
 	}
 
+	if (!options) {
+		options = {};
+	}
+
 	var that = this;
 
 	function retriever(query, callback) {
-		that.get(query.topic, query.index, options, callback);
+		that.get(query.topic, query.index, query.options, callback);
 	}
 
-	mgetAggregate(queries, retriever, cb);
+	mgetAggregate(queries, options, retriever, cb);
 };
 
 
@@ -584,10 +596,10 @@ Archivist.prototype.mgetValues = function (queries, options, cb) {
 	var that = this;
 
 	function retriever(query, callback) {
-		that.getValue(query.topic, query.index, options, callback);
+		that.getValue(query.topic, query.index, query.options, callback);
 	}
 
-	mgetAggregate(queries, retriever, cb);
+	mgetAggregate(queries, options, retriever, cb);
 };
 
 

--- a/lib/archivist/index.js
+++ b/lib/archivist/index.js
@@ -660,6 +660,24 @@ Archivist.prototype.list = function (topic, partialIndex, options, cb) {
 	);
 };
 
+// OPERATION: scan
+
+Archivist.prototype.scan = function (topic, partialIndex, options, cb) {
+	if (!cb) {
+		cb = options;
+		options = null;
+	}
+
+	this.list(topic, partialIndex, options, (error, indexes) => {
+		if (error) {
+			return cb(error);
+		}
+
+		const queries = indexes.map((index) => ({ topic, index }));
+		this.mget(queries, options, cb);
+	});
+};
+
 // OPERATION: AddToCache
 
 Archivist.prototype.addToCache = function (topic, index, data, mediaType, encoding) {

--- a/lib/archivist/index.js
+++ b/lib/archivist/index.js
@@ -1,13 +1,15 @@
-var mage = require('../mage');
-var logger = mage.core.logger.context('archivist');
-var vaultValueLib = require('./vaultValue');
-var VaultValue = vaultValueLib.VaultValue;
-var configuration = require('./configuration');
-var createTrueName = require('rumplestiltskin').trueName;
-var async = require('async');
-var EventEmitter = require('events').EventEmitter;
+'use strict';
 
-var testAggressively = mage.isDevelopmentMode('archivistInspection');
+const mage = require('../mage');
+const logger = mage.core.logger.context('archivist');
+const vaultValueLib = require('./vaultValue');
+const VaultValue = vaultValueLib.VaultValue;
+const configuration = require('./configuration');
+const createTrueName = require('rumplestiltskin').trueName;
+const async = require('async');
+const EventEmitter = require('events').EventEmitter;
+
+const testAggressively = mage.isDevelopmentMode('archivistInspection');
 
 
 exports = module.exports = new EventEmitter();
@@ -516,40 +518,27 @@ function mgetAggregate(queries, options, retriever, cb) {
 	//   OR:
 	// queries: { uniqueID: { topic: 'foo', index: { id: 1 } }, uniqueID2: { etc }
 
-	function arrayQuery() {
-		async.mapSeries(queries, retriever, cb);
-	}
+	const getQueryOptions = (query) => Object.assign({}, options, query.options);
+
+	const arrayQuery = () => async.mapSeries(queries, (query, callback) => {
+		retriever(query, getQueryOptions(query), callback);
+	}, cb);
 
 	function objectQuery() {
-		var result = {};
+		const queryIds = Object.keys(queries);
+		const result = {};
 
 		async.forEachSeries(
-			Object.keys(queries),
-			function (queryId, callback) {
+			queryIds,
+			(queryId, callback) => {
 				const query = queries[queryId];
 
-				if (!query.options) {
-					query.options = {};
-				}
-
-				query.options = Object.assign({}, options, query.options);
-
-				retriever(query, function (error, data) {
-					if (error) {
-						callback(error);
-					} else {
-						result[queryId] = data;
-						callback();
-					}
+				retriever(query, getQueryOptions(query), function (error, data) {
+					result[queryId] = data;
+					callback(error);
 				});
 			},
-			function (error) {
-				if (error) {
-					cb(error);
-				} else {
-					cb(null, result);
-				}
-			}
+			(error) => cb(error, error ? null : result)
 		);
 	}
 
@@ -571,15 +560,9 @@ Archivist.prototype.mget = function (queries, options, cb) {
 		options = undefined;
 	}
 
-	if (!options) {
-		options = {};
-	}
-
-	var that = this;
-
-	function retriever(query, callback) {
-		that.get(query.topic, query.index, query.options, callback);
-	}
+	const retriever = (query, queryOptions, callback) => {
+		this.get(query.topic, query.index, queryOptions, callback);
+	};
 
 	mgetAggregate(queries, options, retriever, cb);
 };
@@ -593,11 +576,9 @@ Archivist.prototype.mgetValues = function (queries, options, cb) {
 		options = undefined;
 	}
 
-	var that = this;
-
-	function retriever(query, callback) {
-		that.getValue(query.topic, query.index, query.options, callback);
-	}
+	const retriever = (query, queryOptions, callback) => {
+		this.getValue(query.topic, query.index, queryOptions, callback);
+	};
 
 	mgetAggregate(queries, options, retriever, cb);
 };

--- a/mage.ts
+++ b/mage.ts
@@ -89,7 +89,7 @@ declare class Archivist {
     mgetValues(queries: mage.archivist.IArchivistQuery[], callback: mage.archivist.ArchivistMGetCallback<mage.archivist.IVaultValue>): void;
 
     /**
-     * Scan the backend vault for matching indexes, and return them
+     * Search the backend vault for matching indexes, and return them
      *
      * In this case, the index can be partial; for instance, `{ userId: 1 }`, would match
      * all the following indexes:
@@ -100,9 +100,7 @@ declare class Archivist {
      * ```
      *
      * Note that this API returns the list of matching *indexes*, not the data they hold;
-     * to fetch the data, you will want to call `mget` using the returned list of indexes.
-     *
-     * See https://mage.github.io/mage/#key-based-filtering for more details.
+     * please see `scan()` if you wish to retrieve the data instead.
      *
      * @param {string} topicName
      * @param {ArchivistIndex} partialIndex
@@ -113,6 +111,27 @@ declare class Archivist {
      */
     list(topicName: string, partialIndex: mage.archivist.IArchivistIndex, options: mage.archivist.IArchivistListOptions | undefined, callback: mage.archivist.ArchivistListCallback): void;
     list(topicName: string, partialIndex: mage.archivist.IArchivistIndex, callback: mage.archivist.ArchivistListCallback): void;
+
+    /**
+     * Scan the backend vault for entries matching a given partial index.
+     *
+     * In this case, the index can be partial; for instance, `{ userId: 1 }`, would match
+     * all the following indexes:
+     *
+     * ```json
+     * { userId: 1, somethingElse: 'hi'}
+     * { userId: 1, somethingElse: 'hello'}
+     * ```
+     *
+     * @param {string} topicName
+     * @param {ArchivistIndex} partialIndex
+     * @param {ArchivistScanOptions} [options]
+     * @param {Function} callback
+     *
+     * @memberOf Archivist
+     */
+    scan<T>(topicName: string, partialIndex: mage.archivist.IArchivistIndex, options: mage.archivist.ArchivistScanOptions | undefined, callback: mage.archivist.ArchivistMGetCallback<T>): void;
+    scan<T>(topicName: string, partialIndex: mage.archivist.IArchivistIndex, callback: mage.archivist.ArchivistMGetCallback<T>): void;
 
     /**
      * Add a new topic value by index.
@@ -1847,6 +1866,11 @@ declare namespace mage {
              */
             chunk: number[];
         }
+
+        /**
+         * Scans can set options for both listing and getting.
+         */
+        type ArchivistScanOptions = IArchivistGetOptions & IArchivistListOptions;
 
         /**
          * Key-value map of index field names and their expected value.

--- a/mage.ts
+++ b/mage.ts
@@ -1886,6 +1886,7 @@ declare namespace mage {
         interface IArchivistQuery {
             topic: string;
             index: IArchivistIndex;
+            options?: IArchivistGetOptions;
         }
 
         /**


### PR DESCRIPTION
  - Added a scan method to archivist, and updated the documentation accordingly.
 -  Per-query option for mget. Query options will be merged with the options passed to the mget call.
