### PR TITLE
batch/messageHooks: state metadata

### DIFF
--- a/lib/commandCenter/commandCenter.js
+++ b/lib/commandCenter/commandCenter.js
@@ -671,6 +671,10 @@ CommandCenter.prototype.executeBatch = function (acceptedEncodings, batch, query
 
 	state.appName = this.app.name;
 
+	if (metaData) {
+		state.data = metaData;
+	}
+
 	exports.emit('openPostConnection', this.app);
 
 	function cb(error, content, options) {


### PR DESCRIPTION
The batching system creates its own `state` independent from the state
created by each user commands. However, it sets no data on `state.data`,
whereas each user commands sets `state.data` to the value of the
metadata received from the batch executor.

This results with `messageHooks` functions receiving different metadata
than what user commands receive.