### PR TITLE
file and memory vaults: large TTLs were unsafe

### DIFF
--- a/lib/archivist/vaults/file/index.js
+++ b/lib/archivist/vaults/file/index.js
@@ -13,6 +13,9 @@ var Archive = require('./Archive');
 var files = require('./files.js');
 var directories = require('./directories.js');
 
+// Required to make sure expirations TTLs are being processed correctly
+var setTimeout = require('safe-timers').setTimeout;
+
 // export the defaultTopicApi
 
 exports.defaultTopicApi = require('./defaultTopicApi');

--- a/lib/archivist/vaults/memory/index.js
+++ b/lib/archivist/vaults/memory/index.js
@@ -1,5 +1,7 @@
 var Archive = require('./Archive');
 
+// Required to make sure expirations TTLs are being processed correctly
+var setTimeout = require('safe-timers').setTimeout;
 
 exports.defaultTopicApi = require('./defaultTopicApi');
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "node-uuid": "1.4.7",
     "panopticon": "0.2.0",
     "rumplestiltskin": "0.1.0",
+    "safe-timers": "1.0.1",
     "semver": "5.3.0",
     "source-map": "0.1.31",
     "tabalot": "0.8.0",


### PR DESCRIPTION
Ref: https://stackoverflow.com/a/3468650/262831

Due to `setTimeout` timer value limitations, both the
file vault backend and the in-memory backend suffer from
a bug where TTL values around 24 days or bigger will cause
the callback function to be executed immediately - meaning,
in both cases, that the values attached to those TTLs would
end up being immediately be deleted.