### PR TITLE
Archivist: return an error if no vaults are avail.

### DIFF
--- a/lib/archivist/index.js
+++ b/lib/archivist/index.js
@@ -422,6 +422,18 @@ Archivist.prototype.getValue = function (topic, index, options, cb) {
 		// load the value from a vault
 
 		var vaults = that.getReadVaults();
+
+		if (vaults.length === 0) {
+			var message = `No read vaults found for topic "${topic}"`;
+			logger.error
+				.details('Make sure to configure the vault backend for this topic, and that')
+				.details('this vault backend is listed under "archivist.vault.readOrder"')
+				.details('in your configuration')
+				.log(message);
+
+			return cb(new Error(message));
+		}
+
 		var readOrder = configuration.getReadOrder();
 		var vaultNum = 0;
 


### PR DESCRIPTION
If no vaults are available, archivist simply returns that
a value has not been found, instead of returning an error
that the vault for a given topic could not be found under
the `readOrder` configuration.