### PR TITLE
longThreshold configuration was ignored

### DIFF
--- a/lib/httpServer/transports/http/index.js
+++ b/lib/httpServer/transports/http/index.js
@@ -91,6 +91,10 @@ exports.initialize = function (mageLogger, cfg) {
 	var cfgLongRoutes = cfg.longRoutes || [];
 	var cfgQuietRoutes = cfg.quietRoutes || [];
 
+	if (cfg.longThreshold) {
+		longThreshold = cfg.longThreshold / 1000;
+	}
+
 	if (cfg.clientHost && cfg.clientHost.closeTimeout) {
 		closeTimeout = cfg.clientHost.closeTimeout;
 	}


### PR DESCRIPTION
The default threshold for logging a call as slow was meant
to be configurable, but the configuration entry was never read.