### PR TITLE
processManager: mage worker id and parallelism fix

### DIFF
--- a/lib/loggingService/writers/graylog.js
+++ b/lib/loggingService/writers/graylog.js
@@ -2,7 +2,9 @@ var util = require('util');
 var requirePeer = require('codependency').get('mage');
 var Writer = require('../Writer');
 var Graylog = requirePeer('graylog2').graylog;
-var cluster = require('cluster');
+
+
+var workerId = require('lib/mage/worker').getId();
 
 
 function GraylogWriter(cfg) {
@@ -89,8 +91,8 @@ GraylogWriter.prototype.channelFunctionGenerator = function (channel) {
 
 	var role;
 
-	if (cluster.worker) {
-		role = '(w:' + cluster.worker.id + ')';
+	if (workerId) {
+		role = '(w:' + workerId + ')';
 	} else {
 		role = '(m)';
 	}

--- a/lib/loggingService/writers/syslog.js
+++ b/lib/loggingService/writers/syslog.js
@@ -1,8 +1,9 @@
 var util = require('util');
 var Writer = require('../Writer');
-var cluster = require('cluster');
 var dgram = require('dgram');
 var hostname = require('os').hostname();
+
+var workerId = require('lib/mage/worker').getId();
 
 // syslog rfc: http://tools.ietf.org/html/rfc5424
 
@@ -80,8 +81,8 @@ SyslogWriter.prototype.channelFunctionGenerator = function (channelName) {
 
 	var role;
 
-	if (cluster.worker) {
-		role = '(w:' + cluster.worker.id + ')';
+	if (workerId) {
+		role = '(w:' + workerId + ')';
 	} else {
 		role = '(m)';
 	}

--- a/lib/mage/Mage.js
+++ b/lib/mage/Mage.js
@@ -41,6 +41,7 @@ function testEngineVersion(pkg, pkgPath, mage) {
 function Mage(mageRootModule) {
 	EventEmitter.call(this);
 
+	this.workerId = require('./worker').getId();
 	this.task = null;
 
 	this._runState = 'init';

--- a/lib/mage/worker.js
+++ b/lib/mage/worker.js
@@ -1,0 +1,11 @@
+'user strict';
+
+exports.getId = function () {
+	const id = process.env.MAGE_WORKER_ID;
+
+	if (!id) {
+		return false;
+	}
+
+	return parseInt(id, 10);
+};

--- a/lib/processManager/processManager.js
+++ b/lib/processManager/processManager.js
@@ -14,6 +14,12 @@ var numberOfWorkers = false;
 
 var realStartTime = Date.now();
 
+var workersIncrement = 0;
+
+function generateWorkerId() {
+	return workersIncrement += 1;
+}
+
 // expose information
 
 processManager.isMaster = false;  // true if the process is the master of the cluster (false for single-node mode)
@@ -73,7 +79,6 @@ function WorkerManager(initialMax) {
 
 	this.max = initialMax;
 	this.maxStartupTime = WORKER_STARTUP_TIMEOUT;
-	this.parallelism = 4;
 
 	// worker lists
 
@@ -113,7 +118,7 @@ WorkerManager.prototype.setupWorkerPhaseManagement = function () {
 	function createStartupTimeout(worker) {
 		timers[worker.id] = setTimeout(function () {
 			logger.alert(
-				'Worker', worker.process.pid, 'took more than', maxStartupTime / 1000,
+				'Worker', worker.mageWorkerId, 'took more than', maxStartupTime / 1000,
 				'sec to startup, shutting down...'
 			);
 
@@ -124,7 +129,7 @@ WorkerManager.prototype.setupWorkerPhaseManagement = function () {
 	}
 
 	cluster.on('fork', function (worker) {
-		logger.verbose('Worker', worker.process.pid, 'has been created.');
+		logger.verbose('Worker', worker.mageWorkerId, 'has been created.');
 
 		that.setWorkerPhase(worker, PHASE_CREATED);
 		workers.push(worker);
@@ -133,14 +138,14 @@ WorkerManager.prototype.setupWorkerPhaseManagement = function () {
 	});
 
 	cluster.on('online', function (worker) {
-		logger.verbose('Worker', worker.process.pid, 'has started.');
+		logger.verbose('Worker', worker.mageWorkerId, 'has started.');
 
 		that.setWorkerPhase(worker, PHASE_STARTED);
 	});
 
 	cluster.on('listening', function (worker, address) {
 		logger.verbose.data(address).log(
-			'Worker', worker.process.pid, 'is ready to accept requests.'
+			'Worker', worker.mageWorkerId, 'is ready to accept requests.'
 		);
 
 		that.setWorkerPhase(worker, PHASE_READY);
@@ -149,18 +154,26 @@ WorkerManager.prototype.setupWorkerPhaseManagement = function () {
 	});
 
 	cluster.on('disconnect', function (worker) {
-		logger.verbose.log('Worker', worker.process.pid, 'is shutting down.');
+		logger.verbose.log('Worker', worker.mageWorkerId, 'is shutting down.');
 
 		that.setWorkerPhase(worker, PHASE_SHUTDOWN);
 	});
 
 	cluster.on('exit', function (worker, code, signal) {
-		var info = '(pid: ' + worker.process.pid + ', code: ' + code + ', signal: ' + signal + ')';
+		var info = {
+			pid: worker.process.pid,
+			code: code,
+			signal: signal
+		};
 
 		if (worker._mageManagedExit || code === 0) {
-			logger.verbose('Worker', worker.id, 'committed graceful suicide', info);
+			logger.verbose
+				.data(info)
+				.log('Worker', worker.mageWorkerId, 'committed graceful suicide');
 		} else {
-			logger.alert('Worker', worker.id, 'died unexpectedly!', info);
+			logger.alert
+				.data(info)
+				.log('Worker', worker.mageWorkerId, 'died unexpectedly!', info);
 		}
 
 		dropStartupTimeout(worker.id);
@@ -187,8 +200,10 @@ WorkerManager.prototype.setupReviver = function () {
 			// this exit was not supposed to happen!
 			// spawn a new worker to replace the dead one
 
-			processManager.emit('workerOffline', worker.id);
-			that.createWorker();
+			var id = worker.mageWorkerId;
+
+			processManager.emit('workerOffline', id);
+			that.createWorker(id);
 		} else {
 			if (!that.workers.length) {
 				logger.emergency('All workers have shut down, shutting down master now.');
@@ -199,8 +214,9 @@ WorkerManager.prototype.setupReviver = function () {
 };
 
 
-WorkerManager.prototype.createWorker = function (cb) {
+WorkerManager.prototype.createWorker = function (id, cb) {
 	// cb is called exactly once: when the worker starts listening, or when listening failed
+	id = id || generateWorkerId();
 
 	var worker, success, failure;
 
@@ -216,7 +232,7 @@ WorkerManager.prototype.createWorker = function (cb) {
 	failure = function (code) {
 		worker.removeListener('listening', success);
 
-		logger.alert('Worker ' + worker.process.pid + ' exited prematurely.');
+		logger.alert('Worker ' + id + ' (pid: ' + worker.process.pid + ') exited prematurely.');
 
 		if (cb) {
 			cb(new Error('Code: ' + code));
@@ -227,8 +243,12 @@ WorkerManager.prototype.createWorker = function (cb) {
 
 	worker = cluster.fork({
 		MASTER_PID: process.pid,
+		MAGE_WORKER_ID: id,
 		CLUSTER_START_TIME: processManager.startTime
 	});
+
+	// Override the ID
+	worker.mageWorkerId = id;
 	worker._mageManagedExit = true;
 
 	worker.once('listening', success);
@@ -245,7 +265,7 @@ WorkerManager.prototype.killWorker = function (worker, cb) {
 
 	var timer = setTimeout(function () {
 		logger.error(
-			'Failed to gracefully stop worker', worker.process.pid, 'after',
+			'Failed to gracefully stop worker', worker.mageWorkerId, 'after',
 			shutdownGracePeriod, 'seconds. Killing it with SIGKILL (-9)...'
 		);
 
@@ -332,7 +352,7 @@ WorkerManager.prototype.shutdown = function (cb) {
 };
 
 
-WorkerManager.prototype.recycle = function (cb) {
+WorkerManager.prototype.recycle = function (parallelism, cb) {
 	var killList = this.workers.slice().reverse(); // we'll pop, so the oldest worker comes first
 	var spawnCount = this.max;
 	var spawned = 0;
@@ -346,9 +366,12 @@ WorkerManager.prototype.recycle = function (cb) {
 	}
 
 	function createWorker(callback) {
+		var processToReplace = killList[killList.length - 1];
+		var id = processToReplace ? processToReplace.mageWorkerId : null;
+
 		spawned += 1;
 
-		that.createWorker(function (error) {
+		that.createWorker(id, function (error) {
 			if (!error) {
 				incProgress();
 			}
@@ -398,17 +421,13 @@ WorkerManager.prototype.recycle = function (cb) {
 
 	// create recycle workers for parallel execution
 
-	if (this.parallelism > 1) {
-		var recycleWorkers = [];
+	var recycleWorkers = [];
 
-		for (var i = 0; i < this.parallelism; i++) {
-			recycleWorkers.push(recycler);
-		}
-
-		async.parallel(recycleWorkers, cb);
-	} else {
-		recycler(cb);
+	for (var i = 0; i < parallelism; i++) {
+		recycleWorkers.push(recycler);
 	}
+
+	async.parallel(recycleWorkers, cb);
 };
 
 
@@ -583,7 +602,8 @@ processManager.start = function (cb) {
 
 	workerManager = new WorkerManager(numberOfWorkers);
 
-	workerManager.recycle(function (error) {
+	// Start all workers at once
+	workerManager.recycle(numberOfWorkers, function (error) {
 		if (error) {
 			logger.emergency('Error while starting workers:', error);
 			process.exit(-1);
@@ -599,7 +619,8 @@ processManager.start = function (cb) {
 
 processManager.reload = function (cb) {
 	if (workerManager) {
-		workerManager.recycle(cb);
+		// Recycle one worker at a time
+		workerManager.recycle(1, cb);
 	} else {
 		cb(new Error('Can only reload master processes'));
 	}

--- a/mage.ts
+++ b/mage.ts
@@ -1280,6 +1280,17 @@ declare class Mage extends NodeJS.EventEmitter {
     isCodeFileExtension(ext: string): boolean;
 
     /**
+     * The worker ID of the currently worker process
+     *
+     * Will return false if the process is the master process, or
+     * if MAGE is running in single mode.
+     *
+     * This differs from cluster.worker.id because it will remain consistent
+     * if restarted or reloaded.
+     */
+    workerId?: number;
+
+    /**
      * The current task to execute. Internal value.
      * @memberof Mage
      */


### PR DESCRIPTION
Parallelism for worker restart was set to 4, and never changed;
instead, we now tell to start all workers at once on start, and
to reload them one by one on reload.

Unique ID per worker; if a worker dies and is replaced,
the replaced worker will have the same `mage.workerId`,
thus allowing for more consistent logging and metrics.