### PR TITLE
mmrp: relay map corruption

### DIFF
--- a/lib/msgServer/index.js
+++ b/lib/msgServer/index.js
@@ -587,19 +587,7 @@ function setupDiscovery() {
 			return;
 		}
 
-/*  // WHY IS THIS COMMENTED OUT? I HAVE NO IDEA!
-		// ignore clusterId-less peers
-
-		if (!data.clusterId) {
-			logger.debug.data({
-				peer: data,
-				us: ourMetadata
-			}).log('Ignoring service-down of service without clusterId:', announced.host + ':' + announced.port);
-			return;
-		}
-*/
-
-		mmrpNode.relayDown(uri);
+		mmrpNode.relayDown(uri, data.clusterId);
 	});
 
 	// announce our relay

--- a/lib/msgServer/index.js
+++ b/lib/msgServer/index.js
@@ -450,7 +450,8 @@ function setupDiscovery() {
 	var ourMetadata = {
 		game: cfgServiceName || mage.rootPackage.name,
 		version: mage.rootPackage.version,
-		clusterId: mmrpNode.clusterId
+		clusterId: mmrpNode.clusterId,
+		timestamp: Date.now()
 	};
 
 	service = serviceDiscovery.createService('mmrp', 'tcp');
@@ -517,36 +518,33 @@ function setupDiscovery() {
 		var data = announced.data;
 
 		if (!uri) {
-			logger.error.data(data).log(
+			return logger.error.data(data).log(
 				'Service "mmrp" up at', announced.host + ':' + announced.port,
 				'but could not resolve hostname.'
 			);
-			return;
 		}
 
 		// ignore versions that are not exactly the same as us
 
 		if (!isVersionMatch(announced)) {
-			logger.debug.data({
+			return logger.debug.data({
 				peer: data,
 				us: ourMetadata
 			}).log('Ignoring service-up of wrong version:', announced.host + ':' + announced.port);
-			return;
 		}
 
 		// ignore clusterId-less peers
 
 		if (!data.clusterId) {
-			logger.debug.data({
+			return logger.debug.data({
 				peer: data,
 				us: ourMetadata
 			}).log('Ignoring service-up of service without clusterId:', announced.host + ':' + announced.port);
-			return;
 		}
 
 		// relays connect to other relays, and clients connect to their own master process
 
-		mmrpNode.relayUp(uri, data.clusterId);
+		mmrpNode.relayUp(uri, data, announced.isLocal());
 	});
 
 	// relays should disconnect from other relays when they disappear
@@ -587,7 +585,7 @@ function setupDiscovery() {
 			return;
 		}
 
-		mmrpNode.relayDown(uri, data.clusterId);
+		mmrpNode.relayDown(uri, data);
 	});
 
 	// announce our relay

--- a/lib/msgServer/mmrp/index.js
+++ b/lib/msgServer/mmrp/index.js
@@ -1,23 +1,25 @@
-var requirePeer = require('codependency').get('mage');
+'use strict';
 
-var assert = require('assert');
-var zmq = requirePeer('zmq');
-var util = require('util');
-var EventEmitter = require('events').EventEmitter;
-var Envelope = require('./Envelope.js');
-var mage = require('../../mage');
-var logger = mage.core.logger.context('mmrp');
-var createDealer = require('./createDealer.js');
-var createRouter = require('./createRouter.js');
-var slice = Array.prototype.slice;
+const requirePeer = require('codependency').get('mage');
+
+const assert = require('assert');
+const zmq = requirePeer('zmq');
+const util = require('util');
+const EventEmitter = require('events').EventEmitter;
+const Envelope = require('./Envelope.js');
+const mage = require('../../mage');
+const logger = mage.core.logger.context('mmrp');
+const createDealer = require('./createDealer.js');
+const createRouter = require('./createRouter.js');
+const slice = Array.prototype.slice;
 
 exports.zmqVersion = zmq.version;
 
 exports.Envelope = Envelope;
 
-var SEND_RETRY_INTERVAL = 200;
+const SEND_RETRY_INTERVAL = 200;
 
-var inProcessDealerCount = {};
+const inProcessDealerCount = {};
 
 
 function createDealerIdentity(clusterId) {
@@ -136,8 +138,27 @@ MmrpNode.prototype.connect = function (uri, clusterId, cb) {
 	assert.strictEqual(typeof uri, 'string');
 	assert.strictEqual(typeof clusterId, 'string');
 
-	var route = [clusterId];
-	var relay = this.relays[clusterId];
+	// check if other relay(s) with the same URI exist, and disconnect them;
+	// this is required to clean up old relays that have yet to be removed
+	// from the relay list
+
+	for (const relayClusterId in this.relays) {
+		const relay =  this.relays[relayClusterId];
+
+		if (relayClusterId !== clusterId && relay.uri === uri) {
+			logger.verbose.data({
+				oldRelayId: relayClusterId,
+				newRelayId: clusterId
+			}).log(this.clusterId, 'found relay with same uri, disconnecting the relay');
+
+			this.disconnect(uri, relayClusterId);
+		}
+	}
+
+	// create route, and look up the relay map
+
+	const route = [clusterId];
+	const relay = this.relays[clusterId];
 
 	// if we're already connected to this URI, we ignore this request
 
@@ -168,25 +189,28 @@ MmrpNode.prototype.connect = function (uri, clusterId, cb) {
  * Disconnects the dealer from a given URI (if connected)
  *
  * @param {string} uri
+ * @param {string} clusterId
  */
 
-MmrpNode.prototype.disconnect = function (uri) {
-	var clusterIds = Object.keys(this.relays);
-	for (var i = 0; i < clusterIds.length; i += 1) {
-		var clusterId = clusterIds[i];
-		var conn = this.relays[clusterId];
+MmrpNode.prototype.disconnect = function (uri, clusterId) {
+	const relay = this.relays[clusterId];
+	const verbose = logger.verbose.data({
+		uri,
+		clusterId
+	});
 
-		if (conn.uri === uri) {
-			delete this.relays[clusterId];
-
-			logger.verbose(this.clusterId, 'dealer disconnecting from', uri, '(cluster: ' + clusterId + ')');
-
-			this.dealer.disconnect(uri);
-			return;
-		}
+	if (!relay) {
+		return verbose.log(this.clusterId, 'dealer disconnect requested but relay does not exist');
 	}
-};
 
+	if (uri !== relay.uri) {
+		throw new Error(`Relay uri appears to be incorrect (received ${uri}, relay's uri is ${relay.uri})`);
+	}
+
+	delete this.relays[clusterId];
+	verbose.log(this.clusterId, 'dealer disconnecting');
+	this.dealer.disconnect(relay.uri);
+};
 
 /**
  * Announce a relay as available. It should be connected to if appropriate.
@@ -228,7 +252,10 @@ MmrpNode.prototype.relayUp = function (uri, clusterId, cb) {
 		return;
 	}
 
-	logger.verbose(this.clusterId, 'attempting to connect to', uri);
+	logger.verbose.data({
+		clusterId,
+		uri
+	}).log(this.clusterId, 'attempting to connect');
 
 	this.connect(uri, clusterId, cb);
 };
@@ -240,10 +267,13 @@ MmrpNode.prototype.relayUp = function (uri, clusterId, cb) {
  * @param {string} uri
  */
 
-MmrpNode.prototype.relayDown = function (uri) {
-	logger.verbose(this.clusterId, 'attempting to disconnect from', uri);
+MmrpNode.prototype.relayDown = function (uri, clusterId) {
+	logger.verbose.data({
+		clusterId,
+		uri
+	}).log(this.clusterId, 'attempting to disconnect');
 
-	this.disconnect(uri);
+	this.disconnect(uri, clusterId);
 };
 
 
@@ -277,6 +307,14 @@ MmrpNode.prototype.sendOnSocket = function (socket, envelope, attempts, cb) {
 
 	attempts = attempts || 1;
 
+	// Debug log entry, if necessary
+	const debug = logger.debug.data({
+		relays: that.relays,
+		clients: that.clients,
+		route: route,
+		attempts: attempts
+	});
+
 	function send() {
 		currentAttempt += 1;
 
@@ -289,12 +327,7 @@ MmrpNode.prototype.sendOnSocket = function (socket, envelope, attempts, cb) {
 			}
 
 			if (currentAttempt === attempts) {
-				logger.debug.data({
-					relays: that.relays,
-					clients: that.clients,
-					route: route,
-					attempts: attempts
-				}).log('Error sending message through ' + sockName + ':', error);
+				debug.log('Error sending message through ' + sockName + ':', error);
 
 				if (cb) {
 					cb.call(that, error);
@@ -303,7 +336,7 @@ MmrpNode.prototype.sendOnSocket = function (socket, envelope, attempts, cb) {
 			}
 
 			if (currentAttempt === 1) {
-				logger.debug('Failed to send envelope, trying up to', attempts, 'times', error);
+				debug.log('Failed to send envelope, trying up to', attempts, 'times', error);
 			}
 
 			setTimeout(send, SEND_RETRY_INTERVAL);

--- a/lib/msgServer/mmrp/index.js
+++ b/lib/msgServer/mmrp/index.js
@@ -21,6 +21,8 @@ const SEND_RETRY_INTERVAL = 200;
 
 const inProcessDealerCount = {};
 
+// Call the callback if defined
+const callMeMaybe = (cb, error) => cb && cb(error);
 
 function createDealerIdentity(clusterId) {
 	// because of unit tests, etc, using a PID for unique dealers is not enough, we also need a counter
@@ -35,7 +37,7 @@ function createDealerIdentity(clusterId) {
 }
 
 
-function RelayConnection(uri, route) {
+function RelayConnection(uri, route, timestamp) {
 	if (uri) {
 		assert.strictEqual(typeof uri, 'string');
 	}
@@ -45,6 +47,7 @@ function RelayConnection(uri, route) {
 
 	this.uri = uri;
 	this.route = route.map(String);
+	this.timestamp = timestamp;
 	this.identity = this.route[this.route.length - 1];
 }
 
@@ -132,7 +135,10 @@ exports.MmrpNode = MmrpNode;
  * @param {Function} [cb]
  */
 
-MmrpNode.prototype.connect = function (uri, clusterId, cb) {
+MmrpNode.prototype.connect = function (uri, data, cb) {
+	const clusterId = data.clusterId;
+	const timestamp = data.timestamp;
+
 	// we cannot connect through routers (long routes), we are establishing a direct connection
 
 	assert.strictEqual(typeof uri, 'string');
@@ -143,16 +149,33 @@ MmrpNode.prototype.connect = function (uri, clusterId, cb) {
 	// from the relay list
 
 	for (const relayClusterId in this.relays) {
-		const relay =  this.relays[relayClusterId];
+		const relay = this.relays[relayClusterId];
 
-		if (relayClusterId !== clusterId && relay.uri === uri) {
-			logger.verbose.data({
-				oldRelayId: relayClusterId,
-				newRelayId: clusterId
-			}).log(this.clusterId, 'found relay with same uri, disconnecting the relay');
-
-			this.disconnect(uri, relayClusterId);
+		// Filter out our own relay
+		if (relayClusterId === clusterId) {
+			continue;
 		}
+
+		// Filter out relays with a different URI
+		if (relay.uri !== uri) {
+			continue;
+		}
+
+		// If we find a more recent node in our
+		// list, we should then ignore adding
+		// the node we have just received overall
+		if (relay.timestamp >= timestamp) {
+			return callMeMaybe(cb);
+		}
+
+		logger.verbose.data({
+			oldRelayId: relayClusterId,
+			newRelayId: clusterId
+		}).log(this.clusterId, 'found relay with same uri, removing the relay');
+
+		// We delete the relay reference, but do not disconnect; quick disconnect-reconnect
+		// appear to confuse ZeroMQ, and may permanently break the connection in some cases.
+		delete this.relays[relayClusterId];
 	}
 
 	// create route, and look up the relay map
@@ -163,16 +186,13 @@ MmrpNode.prototype.connect = function (uri, clusterId, cb) {
 	// if we're already connected to this URI, we ignore this request
 
 	if (relay && relay.uri) {
-		if (cb) {
-			cb();
-		}
-		return;
+		return callMeMaybe(cb);
 	}
 
 	if (relay) {
 		relay.uri = uri;
 	} else {
-		this.relays[clusterId] = new RelayConnection(uri, route);
+		this.relays[clusterId] = new RelayConnection(uri, route, timestamp);
 	}
 
 	logger.verbose(this.clusterId, 'dealer connecting to', uri, '(cluster: ' + clusterId + ')');
@@ -196,11 +216,12 @@ MmrpNode.prototype.disconnect = function (uri, clusterId) {
 	const relay = this.relays[clusterId];
 	const verbose = logger.verbose.data({
 		uri,
-		clusterId
+		localClusterId: this.clusterId,
+		receivedClusterId: clusterId
 	});
 
 	if (!relay) {
-		return verbose.log(this.clusterId, 'dealer disconnect requested but relay does not exist');
+		return verbose.log('dealer disconnect requested but relay does not exist');
 	}
 
 	if (uri !== relay.uri) {
@@ -208,7 +229,7 @@ MmrpNode.prototype.disconnect = function (uri, clusterId) {
 	}
 
 	delete this.relays[clusterId];
-	verbose.log(this.clusterId, 'dealer disconnecting');
+	verbose.log('dealer disconnecting');
 	this.dealer.disconnect(relay.uri);
 };
 
@@ -219,45 +240,49 @@ MmrpNode.prototype.disconnect = function (uri, clusterId) {
  * @param {string} clusterId
  */
 
-MmrpNode.prototype.relayUp = function (uri, clusterId, cb) {
-	// relays ignore self
+MmrpNode.prototype.relayUp = function (uri, data, isLocal, cb) {
+	const clusterId = data.clusterId;
 
-	if (this.isRelay && clusterId === this.clusterId) {
-		logger.verbose(this.clusterId, 'own router was announced as up (ignoring).');
-		if (cb) {
-			cb();
-		}
-		return;
-	}
+	// Log entry
 
-	// if there is no router set up, we are strictly a worker and connect only to our master router
+	const verbose = logger.verbose.data({
+		uri,
+		isLocal,
+		localClusterId: this.clusterId,
+		receivedClusterId: clusterId
+	});
+
+	const connect = () => this.connect(uri, data, cb);
+
+	// Local workers connect to the local interface created by the master
 
 	if (!this.isRelay) {
 		if (this.isClient && clusterId === this.clusterId) {
-			logger.verbose(this.clusterId, 'client connecting to own relay announced at',
-				uri, '(cluster: ' + clusterId + ')');
-
-			this.connect(uri, clusterId, cb);
-			return;
+			verbose.log('client connecting to own relay');
+			return connect();
 		}
 
-		logger.verbose(
-			this.clusterId, 'ignoring relay announced at', uri, '(cluster: ' + clusterId + ')',
-			'because we are not a relay'
-		);
-
-		if (cb) {
-			cb();
-		}
-		return;
+		logger.verbose('ignoring relay because we are not a relay');
+		return callMeMaybe(cb);
 	}
 
-	logger.verbose.data({
-		clusterId,
-		uri
-	}).log(this.clusterId, 'attempting to connect');
+	// relays ignores its own uri
+	//
+	// When a server dies unexpectedly, it may respawn before
+	// service discovery has cleaned up the dead node; therefore,
+	// we need service discovery to tell us whether it believes the
+	// node to be local or not, instead of relying on the
+	// clusterId as we do in many other places in this code.
 
-	this.connect(uri, clusterId, cb);
+	if (isLocal) {
+		verbose.log('local node was announced as up (ignoring).');
+		return callMeMaybe(cb);
+	}
+
+	// connect to a remote relay (generally a remote master process)
+
+	verbose.log('attempting to connect');
+	connect();
 };
 
 
@@ -267,11 +292,14 @@ MmrpNode.prototype.relayUp = function (uri, clusterId, cb) {
  * @param {string} uri
  */
 
-MmrpNode.prototype.relayDown = function (uri, clusterId) {
+MmrpNode.prototype.relayDown = function (uri, data) {
+	const clusterId = data.clusterId;
+
 	logger.verbose.data({
-		clusterId,
-		uri
-	}).log(this.clusterId, 'attempting to disconnect');
+		uri,
+		localClusterId: this.clusterId,
+		receivedClusterId: clusterId
+	}).log('attempting to disconnect');
 
 	this.disconnect(uri, clusterId);
 };
@@ -288,12 +316,10 @@ MmrpNode.prototype.relayDown = function (uri, clusterId) {
  */
 
 MmrpNode.prototype.sendOnSocket = function (socket, envelope, attempts, cb) {
-	var that = this;
-
-	var sockName = socket === that.router ? 'router' : 'dealer';
-	var route = envelope.route.map(String);
-	var args = envelope.toArgs();
-	var bytes = 0;
+	const sockName = socket === this.router ? 'router' : 'dealer';
+	const route = envelope.route.map(String);
+	const args = envelope.toArgs();
+	let bytes = 0;
 
 	logger.verbose(this.clusterId, 'sending', envelope.type, 'envelope to', route, 'through', sockName);
 
@@ -303,14 +329,14 @@ MmrpNode.prototype.sendOnSocket = function (socket, envelope, attempts, cb) {
 		bytes += args[i].length;
 	}
 
-	var currentAttempt = 0;
+	let currentAttempt = 0;
 
 	attempts = attempts || 1;
 
 	// Debug log entry, if necessary
-	const debug = logger.debug.data({
-		relays: that.relays,
-		clients: that.clients,
+	const debug = () => logger.debug.data({
+		relays: this.relays,
+		clients: this.clients,
 		route: route,
 		attempts: attempts
 	});
@@ -320,23 +346,14 @@ MmrpNode.prototype.sendOnSocket = function (socket, envelope, attempts, cb) {
 
 		socket.send(args, null, function (error) {
 			if (!error) {
-				if (cb) {
-					cb.call(that);
-				}
-				return;
+				return callMeMaybe(cb);
 			}
 
 			if (currentAttempt === attempts) {
-				debug.log('Error sending message through ' + sockName + ':', error);
-
-				if (cb) {
-					cb.call(that, error);
-				}
-				return;
-			}
-
-			if (currentAttempt === 1) {
-				debug.log('Failed to send envelope, trying up to', attempts, 'times', error);
+				debug().log('Error sending message through ' + sockName + ':', error);
+				return callMeMaybe(cb, error);
+			} else if (currentAttempt === 1) {
+				debug().log('Failed to send envelope, trying up to', attempts, 'times', error);
 			}
 
 			setTimeout(send, SEND_RETRY_INTERVAL);
@@ -359,15 +376,11 @@ MmrpNode.prototype.sendOnSocket = function (socket, envelope, attempts, cb) {
  */
 
 MmrpNode.prototype.sendThroughRouter = function (envelope, attempts, cb) {
-	if (!cb) {
-		cb = function () {};
-	}
-
 	// If we're a relay, we always send through our router
 
 	if (!this.router) {
 		logger.warning('Cannot send envelope: router is closed');
-		cb(new Error('Router is closed'));
+		callMeMaybe(cb, new Error('Router is closed'));
 		return 0;
 	}
 
@@ -393,24 +406,20 @@ MmrpNode.prototype.sendThroughRouter = function (envelope, attempts, cb) {
  */
 
 MmrpNode.prototype.sendThroughDealer = function (envelope, attempts, cb) {
-	if (!cb) {
-		cb = function () {};
-	}
-
 	// Sending through the dealer should *only* happen in cluster mode (when we're not a
 	// client AND a relay in a single process) and the dealer is only connected to a single router.
 	// Dealers are round-robin, and we want to route through our routers.
 
 	if (!this.dealer) {
 		logger.warning('Cannot send envelope: dealer is closed');
-		cb(new Error('Dealer is closed'));
+		callMeMaybe(cb, new Error('Dealer is closed'));
 		return 0;
 	}
 
 	var connectionCount = Object.keys(this.relays).length;
 
 	if (connectionCount > 1) {
-		cb(new Error('Client dealer is not allowed to be connected to multiple routers'));
+		callMeMaybe(cb, new Error('Client dealer is not allowed to be connected to multiple routers'));
 		return 0;
 	}
 
@@ -428,10 +437,6 @@ MmrpNode.prototype.sendThroughDealer = function (envelope, attempts, cb) {
  */
 
 MmrpNode.prototype.send = function (envelope, attempts, cb) {
-	if (!cb) {
-		cb = function () {};
-	}
-
 	// if explicitly sent to or through self, deliver it
 
 	if (envelope.consumeRoute(this.identity)) {
@@ -441,14 +446,14 @@ MmrpNode.prototype.send = function (envelope, attempts, cb) {
 	// if no path remains on the route, we're done
 
 	if (!envelope.routeRemains()) {
-		cb();
+		callMeMaybe(cb);
 		return 0;
 	}
 
 	// if broadcast, pass it on
 
 	if (this._handleBroadcastRequest(envelope)) {
-		cb();
+		callMeMaybe(cb);
 		return 0;
 	}
 
@@ -465,7 +470,7 @@ MmrpNode.prototype.send = function (envelope, attempts, cb) {
 	}
 
 	logger.alert('MMRP Node is not a relay nor a client');
-	cb(new Error('MMRP Node is not a relay nor a client'));
+	callMeMaybe(cb, new Error('MMRP Node is not a relay nor a client'));
 	return 0;
 };
 
@@ -703,10 +708,9 @@ MmrpNode.prototype._onRouterMessage = function (args, senderIdentity) {
 
 	var envelope = Envelope.fromArgs(args, senderIdentity);
 
-	var that = this;
-	this.send(envelope, 1, function (error) {
+	this.send(envelope, 1, (error) => {
 		if (error && envelope.hasReturnRoute()) {
-			that.send(new Envelope(
+			this.send(new Envelope(
 				'mmrp.sendError',
 				[error.message, envelope.type].concat(envelope.messages),
 				envelope.returnRoute

--- a/test/msgServer/mmrp.js
+++ b/test/msgServer/mmrp.js
@@ -105,10 +105,14 @@ describe('MMRP', function () {
 			// initiate handshakes
 
 			network.clients.forEach(function (client) {
-				client.relayUp(createUri(network.relay.routerPort), network.relay.clusterId);
+				client.relayUp(createUri(network.relay.routerPort), {
+					clusterId: network.relay.clusterId
+				}, true);
 			});
 
-			network.relay.relayUp(createUri(network.relay.routerPort), network.relay.clusterId);
+			network.relay.relayUp(createUri(network.relay.routerPort), {
+				clusterId: network.relay.clusterId
+			}, true);
 		}
 
 		it('instantiates', function () {
@@ -189,7 +193,9 @@ describe('MMRP', function () {
 
 			relays.forEach(function (relay) {
 				relays.forEach(function (peer) {
-					relay.relayUp(createUri(peer.routerPort), peer.clusterId);
+					relay.relayUp(createUri(peer.routerPort), {
+						clusterId: peer.clusterId
+					}, relay.clusterId === peer.clusterId);
 				});
 			});
 		}
@@ -356,12 +362,18 @@ describe('MMRP', function () {
 			network.relays.forEach(function (relay) {
 				network.clients.forEach(function (clientGroup) {
 					clientGroup.forEach(function (client) {
-						client.relayUp(createUri(relay.routerPort), relay.clusterId);
+						client.relayUp(createUri(relay.routerPort), {
+							clusterId: relay.clusterId,
+							timestamp: Date.now()
+						});
 					});
 				});
 
 				network.relays.forEach(function (peer) {
-					peer.relayUp(createUri(relay.routerPort), relay.clusterId);
+					peer.relayUp(createUri(relay.routerPort), {
+						clusterId: relay.clusterId,
+						timestamp: Date.now()
+					}, peer.clusterId === relay.clusterId);
 				});
 			});
 		}
@@ -434,8 +446,11 @@ describe('MMRP', function () {
 					});
 				}
 
-				network.relays[1].close();
-				network.relays[0].relayDown(createUri(network.relays[1].routerPort));
+				var relay = network.relays[1];
+				relay.close();
+				network.relays[0].relayDown(createUri(relay.routerPort), {
+					clusterId: relay.clusterId
+				});
 
 				sendLoop();
 			});


### PR DESCRIPTION
### Description 

MMRP relies on service discovery to keep its list of known relays
up to date. However, under certain conditions, and depending on the
behavior of the service discovery backend in use, you may end up
with two relays sharing the same URI. This, in and of itself, appeared
to be the cause of multiple issues.

You may also end up with case where lingering nodes are cleaned up
after the replacing node has been added; in such cases, a disconnect was
still triggered, thus leaving the MMRP cluster in an inconsistent state
where messages were silently black-holed.

### Encountered cases

Currently, only when using the ZooKeeper service discovery vault backend. This is because if a server unexpectedly crashes or is terminated with `SIGKILL`, the ZooKeeper node remains in the node tree until it expires.

However, I suspect other service discovery vault backends could potentially cause similar issues - to a certain degree.

### Solution

  1. On relay down, disconnect based on the cluster ID instead
     of disconnecting based on the URI (we still verify that the URI
     is consistent)
  2. On relay up, disconnect any relay with the same URI but a different
     clusterId