### PR TITLE
archivist: cache vs reset

### DIFF
--- a/lib/archivist/index.js
+++ b/lib/archivist/index.js
@@ -198,8 +198,20 @@ function Archivist(state) {
 exports.Archivist = Archivist;
 
 
-Archivist.prototype.clearCache = function () {
+Archivist.prototype.reset = function () {
 	this.loaded = {};
+};
+
+Archivist.prototype.clearCache = function () {
+	const keys = Object.keys(this.loaded);
+
+	for (const key of keys) {
+		const entry = this.loaded[key];
+
+		if (entry.operation === null) {
+			delete this.loaded[key];
+		}
+	}
 };
 
 

--- a/mage.ts
+++ b/mage.ts
@@ -183,9 +183,20 @@ declare class Archivist {
     /**
      * Clear all the loaded entries from this archivist instance
      *
+     * Note that this will not clear mutated entries; please use
+     * `reset()` if you wish to clear all data instead.
+     *
      * @memberOf Archivist
      */
     clearCache(): void;
+
+    /**
+     * Reset the instance; remove all operations that are
+     * currently scheduled on the instance
+     *
+     * @memberOf Archivist
+     */
+    reset(): void;
 }
 
 /**


### PR DESCRIPTION
`clearCache` would clear mutated entries; instead, we now
renamed it to `reset`, and created a new `clearCache` which
only deletes non-mutated entries.

Requires #41 