### PR TITLE
docs: warn users about duplicate b/e cfgs

### DIFF
--- a/docs-sources/includes/_Archivist.md
+++ b/docs-sources/includes/_Archivist.md
@@ -25,6 +25,11 @@ archivist:
 ```
 
 <aside class="warning">
+Never configure multiple vaults to connect to the same vault backend storage!
+This would break how [migration scripts](#migrations) work.
+</aside>
+
+<aside class="warning">
 Not all vaults support every operations! Below you will find
 a short configuration description for each available vault backends
 alongside a list of supported operations for that backend.


### PR DESCRIPTION
We should document the fact that 2 vaults should never share a
database (or bucket, or folder, or whatever), because it messes with
migrations.