### PR TITLE
topics: json as default media type

### DIFF
--- a/lib/archivist/configuration.js
+++ b/lib/archivist/configuration.js
@@ -427,7 +427,7 @@ function registerTopicConfig(topic, cfg) {
 
 	// initialize topicConfig with defaults
 
-	var defaultMediaTypes = ['application/x-tome', 'application/octet-stream'];
+	var defaultMediaTypes = ['application/json'];
 
 	var topicConfig = {
 		readOptions: {


### PR DESCRIPTION
Since Tomes is not widely used (or currently documented, for that
matter), making the default 'application/json' is more comprehensive.