### PR TITLE
Standard MageError class for user-land

### DIFF
--- a/lib/mage/Mage.js
+++ b/lib/mage/Mage.js
@@ -42,6 +42,7 @@ function Mage(mageRootModule) {
 	EventEmitter.call(this);
 
 	this.workerId = require('./worker').getId();
+	this.MageError = require('./MageError');
 	this.task = null;
 
 	this._runState = 'init';

--- a/lib/mage/MageError.js
+++ b/lib/mage/MageError.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const mage = require('lib/mage');
+const loggingService = require('lib/loggingService');
+const logLevels = loggingService.getAllChannelNames();
+
+module.exports = class MageError extends Error {
+	constructor(data) {
+		super(data.message || 'Mage Error');
+
+		this.code = data.code || 'server';
+		this.level = data.level || 'error';
+		this.details = data.details;
+		this.type = 'MageError';
+
+		if (logLevels.indexOf(this.level) === -1) {
+			mage.logger.warning
+				.data(this)
+				.log('Error level is incorrect, setting level to error');
+			this.level = 'error';
+		}
+	}
+};

--- a/lib/mage/MageError.ts
+++ b/lib/mage/MageError.ts
@@ -1,0 +1,53 @@
+/**
+ * MageError details
+ */
+declare interface IErrorDetails {
+    /**
+     * The log level to use when logging this error (default: error)
+     *
+     * Some types of errors are perfectly normal; for instance,
+     * a user failing to authenticate may throw an error, but
+     * you might not want to have it logged as an error.
+     *
+     * Setting the level will allow you to decide whether this
+     * error should be ignored, considered benign, or serious.
+     */
+    level?: 'debug' | 'warning' | 'error' | 'critical' | 'alert' | 'emergency',
+
+    /**
+     * The error code
+     *
+     * This code will generally be the code that will be returned
+     * to the client if this error is thrown during a user command
+     * request.
+     */
+    code: string,
+
+    /**
+     * The error message
+     *
+     * This message will be logged to every log backend you have
+     * configured in your application.
+     */
+    message: string,
+
+    /**
+     * Error details
+     *
+     * Additional details you wish to log
+     */
+    details: any
+};
+
+/**
+ * MageError class
+ *
+ * This class can be used to throw errors that
+ * should both interrupt the execution flow and be
+ * logged by the MAGE logger.
+ */
+declare class MageError extends Error {
+	constructor(data: IErrorDetails);
+};
+
+export = MageError;

--- a/lib/state/state.js
+++ b/lib/state/state.js
@@ -476,7 +476,10 @@ State.prototype.error = function (code, logMessage, cb) {
 
 	// Log the result
 	if (logMessage) {
-		logger.error
+		const logLevel = logMessage.level || 'error';
+		const logEntry = logger[logLevel] || logger.error;
+
+		logEntry
 			.data({
 				description: this.description,
 				actorId: this.actorId

--- a/mage.ts
+++ b/mage.ts
@@ -4,6 +4,7 @@ declare type VaultOperation = 'add' | 'set' | 'del' | 'touch';
 
 import * as commander from 'commander';
 import * as config from './lib/config';
+import * as MageError from './lib/mage/MageError';
 
 /**
  * Abstracted data store access interface
@@ -1265,6 +1266,8 @@ declare interface IMageCore {
 }
 
 declare class Mage extends NodeJS.EventEmitter {
+    MageError: typeof MageError;
+
     /**
      * Check if a file is considered like a source code file in MAGE
      *

--- a/package-lock.json
+++ b/package-lock.json
@@ -443,7 +443,7 @@
         "char-spinner": "1.0.1",
         "condense-whitespace": "1.0.0",
         "default-user-agent": "1.0.0",
-        "errno": "0.1.4",
+        "errno": "0.1.5",
         "extend": "3.0.1",
         "http-equiv-refresh": "1.0.0",
         "humanize-duration": "3.12.0",
@@ -1187,12 +1187,12 @@
       "integrity": "sha1-V9He2h1ryBYisRinX+a1p9NPbYg="
     },
     "errno": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-      "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.5.tgz",
+      "integrity": "sha512-tv2H+e3KBnMmNRuoVG24uorOj3XfYo+/nJJd07PUISRr0kaMKQKL5kyD+6ANXk1ZIIsvbORsjvHnCfC4KIc7uQ==",
       "dev": true,
       "requires": {
-        "prr": "0.0.0"
+        "prr": "1.0.1"
       }
     },
     "error-ex": {
@@ -3919,9 +3919,9 @@
       }
     },
     "prr": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
     "ps-tree": {


### PR DESCRIPTION
This should help:

  1. Standardize error management
  2. Allow for throwing errors (and interrupt the execution flow)
     without necessarily logging an error
  3. Allow to attach additional details to the error to be logged, thus
     removing the need for an additional log call prior to throwing
  4. Attach a response code to be sent to the client; this also has the
     advantage of being part of the log data, thus making it easier
     to search for error occurrences by code instead of by message
     content.

Requires #112 
Fixes #135