### PR TITLE
couchbase helper: ignore auth errors on open

### DIFF
--- a/lib/archivist/vaults/couchbase/couchbaseHelpers.js
+++ b/lib/archivist/vaults/couchbase/couchbaseHelpers.js
@@ -43,12 +43,16 @@ function handleErrorPerErrorCode(error, exemptedCodes, callback) {
  * See https://github.com/couchbase/libcouchbase/blob/master/include/libcouchbase/error.h
  * for more details about the meaning of each error codes.
  *
+ * At this point, the credentials used have already been validated; an auth error
+ * would mean that the bucket has not been created yet.
+ *
  * @summary Handle bucket open errors.
  * @param {Error} error - The received error code
  * @param {Function} callback - The callback function to trigger in both cases
  */
 function handleBucketOpenError(error, callback) {
 	handleErrorPerErrorCode(error, [
+		couchbase.errors.authError,    // LCB_AUTH_ERROR
 		couchbase.errors.protocolError // LCB_PROTOCOL_ERROR
 	], callback);
 }
@@ -401,12 +405,6 @@ function decoder(transcoderDoc) {
 
 
 // Make wait functions public
-exports.waitForSet = waitForSet;
-exports.waitForGet = waitForGet;
-exports.waitForN1QL = waitForN1QL;
-exports.waitForDel = waitForDel;
 exports.createBucket = createBucket;
-
-// Make transcoder functions public
 exports.encoder = encoder;
 exports.decoder = decoder;


### PR DESCRIPTION
An auth fail after a successful bucket creation would
mean that the credentials are valid, but that the
bucket has not fully been created yet.

Privatizing some methods which are not being used anywhere
else than internally.

Fixes #167