### PR TITLE
Update a (now) misleading comment

### DIFF
--- a/lib/state/state.js
+++ b/lib/state/state.js
@@ -107,7 +107,7 @@ function State(actorId, session, opts) {
 	// Information for command response output:
 	this.errorCode = undefined;   // JSON serialized error code to a user command
 	this.response = undefined;    // JSON serialized response to a user command
-	this.myEvents = [];           // array of JSON serialized events for this session
+	this.myEvents = [];           // array of event entries that contain JSON serialized events
 
 	this.otherEvents = {};	// events for other actors: { actorId: [ list of events ], actorId: etc... }
 	this.broadcastEvents = [];


### PR DESCRIPTION
This comment used to be correct, but that the format has changed. This new comment more properly reflects the new make-up of `myEvents`.