### PR TITLE
2 archivist fixes

### DIFF
--- a/lib/archivist/encoders.js
+++ b/lib/archivist/encoders.js
@@ -180,7 +180,7 @@ register('utf8', 'base64', function (data) {
 });
 
 register('base64', 'utf8', function (data) {
-	assertBuffer('base64', 'utf8', data);
+	assertString('base64', 'utf8', data);
 	return (new Buffer(data, 'base64')).toString('utf8');
 });
 

--- a/lib/archivist/vaults/couchbase/defaultTopicApi.js
+++ b/lib/archivist/vaults/couchbase/defaultTopicApi.js
@@ -132,6 +132,10 @@ exports.parseFlags = function (flags) {
  */
 
 exports.serialize = function (value) {
+	if (Buffer.isBuffer(value.data)) {
+		return value.data;
+	}
+
 	// throws exceptions on failure
 
 	return value.setEncoding(['utf8']).data;


### PR DESCRIPTION
This is two commits in one PR, but I could split it up if one commit is an obvious merge and another is not desirable. I wouldn't want to see them squashed in any case, and I believe we need both.

- Archivist: fixes an assertion bug for base64 -> utf8 conversion introduced in 1.3.0
- Archivist: Allows Couchbase to store binary (this is useful for response cache, which up till now was always converted to base64 before writing out to Couchbase). This even broke response-cache, since it causes a gunzip operation client-side on a base64 string instead of a binary blob.