### PR TITLE
Adds tests for archivist encoders

### DIFF
--- a/test/archivist/encodings.js
+++ b/test/archivist/encodings.js
@@ -1,0 +1,52 @@
+const assert = require('assert');
+
+describe('Encoding', function () {
+	const encoders = require('../../lib/archivist/encoders');
+
+	describe('can guess an encoding', function () {
+		it('"hello" -> utf8', function () {
+			assert.equal(encoders.guessEncoding('hello world'), 'utf8');
+		});
+
+		it('"foo" in a Buffer -> buffer', function () {
+			assert.equal(encoders.guessEncoding(new Buffer('foo')), 'buffer');
+		});
+
+		it('plain JS object -> live', function () {
+			assert.equal(encoders.guessEncoding({ a: 'b' }), 'live');
+		});
+	});
+
+	describe('can do simple conversion between encodings', function () {
+		const mediaType = 'some/dummy';
+
+		function enc(from, to, data) {
+			const encoder = encoders.getEncoder(mediaType, from, to);
+			return encoder(data);
+		}
+
+		it('utf8 -> buffer', function () {
+			assert.deepStrictEqual(enc('utf8', 'buffer', 'こんにちは'), new Buffer('こんにちは'));
+		});
+
+		it('base64 -> buffer', function () {
+			assert.deepStrictEqual(enc('base64', 'buffer', 'aGVsbG8='), new Buffer('hello'));
+		});
+
+		it('buffer -> base64', function () {
+			assert.deepStrictEqual(enc('buffer', 'base64', new Buffer('hello')), 'aGVsbG8=');
+		});
+
+		it('buffer -> utf8', function () {
+			assert.deepStrictEqual(enc('buffer', 'utf8', new Buffer('hello')), 'hello');
+		});
+
+		it('utf8 -> base64', function () {
+			assert.deepStrictEqual(enc('utf8', 'base64', 'hello'), 'aGVsbG8=');
+		});
+
+		it('base64 -> utf8', function () {
+			assert.deepStrictEqual(enc('base64', 'utf8', 'aGVsbG8='), 'hello');
+		});
+	});
+});

--- a/test/archivist/index.js
+++ b/test/archivist/index.js
@@ -1,3 +1,4 @@
 describe('archivist', function () {
+	require('./encodings');
 	require('./vaults');
 });


### PR DESCRIPTION
This covers one commit of #171: https://github.com/mage/mage/pull/171/commits/f0332beec4a3d76b07736e805ec971d99e29f3d0