### PR TITLE
Expose worker manager, dropStartupTimeout on workers

### DIFF
--- a/lib/processManager/processManager.js
+++ b/lib/processManager/processManager.js
@@ -129,6 +129,10 @@ WorkerManager.prototype.setupWorkerPhaseManagement = function () {
 		that.setWorkerPhase(worker, PHASE_CREATED);
 		workers.push(worker);
 
+		worker.dropStartupTimeout = function () {
+			dropStartupTimeout(worker.id);
+		};
+
 		createStartupTimeout(worker);
 	});
 
@@ -596,6 +600,9 @@ processManager.start = function (cb) {
 	});
 };
 
+processManager.getWorkerManager = function () {
+	return workerManager;
+};
 
 processManager.reload = function (cb) {
 	if (workerManager) {


### PR DESCRIPTION
These fixes are so to allow more control to external
tools over how the process manager handles restarts.