### PR TITLE
mage.quit, mage.exit

### DIFF
--- a/lib/mage/Mage.js
+++ b/lib/mage/Mage.js
@@ -26,7 +26,7 @@ function testEngineVersion(pkg, pkgPath, mage) {
 
 	if (!semver.satisfies(process.version, range)) {
 		console.error('Node.js version', process.version, 'does not satisfy range', range, 'as configured in', pkgPath);
-		mage.quit(-1);
+		mage.exit(-1);
 	}
 }
 
@@ -223,6 +223,7 @@ Mage.prototype.getTask = function () {
 
 Mage.prototype.setupCoreLibs = function () {
 	var core = this.core;
+	var that = this;
 
 	// Load the configuration
 
@@ -262,19 +263,52 @@ Mage.prototype.setupCoreLibs = function () {
 	core.cmd = require('../commandCenter');
 	core.sampler = require('../sampler');
 
+	// Setup a core messenger system for passing messages between
+	// core systems
+	core.processMessenger = new core.ProcessMessenger('mage.core');
+	core.processMessenger.on('exit', function (message) {
+		that.exit(message.exitCode, message.hard);
+	});
+
 	// Make this chainable.
 	return this;
 };
 
+/**
+ * Close down the MAGE server
+ *
+ * Workers will forward the request to their master if needed.
+ * This differs from `exit` since exit is equivalent to `process.exit`;
+ * see `exit` for more details.
+ *
+ * @param {number}  exitCode An exit code for node to return.
+ * @param {boolean} hard If true, do not wait for all services to close and exit immediately instead
+ */
+Mage.prototype.quit = function (exitCode, hard) {
+	if (this.workerId) {
+		return this.core.processMessenger.send('master', 'exit', {
+			exitCode: exitCode,
+			hard: hard
+		});
+	}
+
+	this.exit(exitCode, hard);
+};
 
 /**
  * Shuts mage down, allowing I/O sensitive subsystems to shut down gracefully.
  * This logic applies to Master and Worker processes alike.
  *
- * @param {Number}  exitCode An exit code for node to return.
+ * `exit` since exit is equivalent to `process.exit`; it will shut down the current
+ * process. Use `quit` if you wish to close down the server and all its processes
+ * instead.
+ *
+ * @param {number}  exitCode An exit code for node to return.
+ * @param {boolean} hard If true, do not wait for all services to close and exit immediately instead
  */
 
-Mage.prototype.quit = function (exitCode, hard) {
+Mage.prototype.exit = function (exitCode, hard) {
+	//
 	if (hard) {
 		console.log('Shutting down HARD.');
 		process.exit(1);
@@ -338,7 +372,7 @@ Mage.prototype.fatalError = function () {
 		this.core.logger.emergency.apply(this.core.logger, arguments);
 	}
 
-	this.quit(-1);
+	this.exit(-1);
 };
 
 
@@ -648,7 +682,7 @@ Mage.prototype.setup = function (cb) {
 			}
 
 			// uncatchable error, shut down mage
-			return that.quit(-1);
+			return that.exit(-1);
 		}
 
 		options = options || {};
@@ -657,7 +691,7 @@ Mage.prototype.setup = function (cb) {
 		if (!options.allowUserCallback) {
 			return that.start(function (error) {
 				if (error) {
-					return that.quit(-1);
+					return that.exit(-1);
 				}
 			});
 		}
@@ -705,7 +739,7 @@ Mage.prototype.start = function (cb) {
 		}
 
 		if (options.shutdown) {
-			that.quit(options.exitCode || 0);
+			that.exit(options.exitCode || 0);
 		}
 	});
 

--- a/lib/mage/Readme.md
+++ b/lib/mage/Readme.md
@@ -76,7 +76,11 @@ only argument.
 
 ### mage.quit(number exitCode)
 
-Shuts down MAGE and exits the process with the given exit code, or 0 if none has been passed.
+Shuts down MAGE and all its processes.
+
+### mage.exit(number exitCode)
+
+Shuts down MAGE and exits the current process with the given exit code, or 0 if none has been passed.
 
 > Please note that if you run this in a worker process, it only shuts down the worker, not the
 > entire project.

--- a/lib/processManager/processManager.js
+++ b/lib/processManager/processManager.js
@@ -499,7 +499,7 @@ processManager.initialize = function (mageInstance, mageLogger, pmConfig) {
 
 		process.on('SIGHUP', function () {
 			logger.notice('Caught SIGHUP, shutting down.');
-			mage.quit();
+			mage.exit();
 		});
 
 		// Quit when CTRL-C is pressed
@@ -509,14 +509,14 @@ processManager.initialize = function (mageInstance, mageLogger, pmConfig) {
 		process.on('SIGINT', function () {
 			sigIntCounter += 1;
 			logger.notice('Caught SIGINT, shutting down.');
-			mage.quit(null, sigIntCounter > 1);
+			mage.exit(null, sigIntCounter > 1);
 		});
 
 		// Quit when the default kill signal (TERM) is received
 
 		process.on('SIGTERM', function () {
 			logger.notice('Caught SIGTERM, shutting down.');
-			mage.quit();
+			mage.exit();
 		});
 
 		// As long as we respond (by simply existing), the caller will be happy.
@@ -535,14 +535,14 @@ processManager.initialize = function (mageInstance, mageLogger, pmConfig) {
 
 		process.on('SIGHUP', function () {
 			logger.notice('Caught SIGHUP, shutting down.');
-			mage.quit();
+			mage.exit();
 		});
 
 		// Listen for shutdown requests (generally coming from the master process)
 
 		process.on('SIGTERM', function () {
 			logger.debug('Worker received shutdown request.');
-			mage.quit();
+			mage.exit();
 		});
 	}
 
@@ -550,7 +550,7 @@ processManager.initialize = function (mageInstance, mageLogger, pmConfig) {
 		logger.emergency('Uncaught exception:', error);
 
 		if (shutdownOnError) {
-			mage.quit(-1);
+			mage.exit(-1);
 		}
 	});
 

--- a/mage.ts
+++ b/mage.ts
@@ -1395,18 +1395,34 @@ declare class Mage extends NodeJS.EventEmitter {
     getTask(): mage.core.ITask;
 
     /**
+     * Quit MAGE
+     *
+     * This will stop ALL MAGE processes regardless of where it
+     * is called from. To stop only the local process (similarly
+     * to what `process.exit` would do, please see `mage.exit`)
+     *
+     * @param {number} [exitCode] exit code to use
+     * @param {boolean} [hard] If true, exit immediately (exit code will be ignored and set to 1)
+     */
+    quit(exitCode?: number, hard?: boolean) : never;
+
+    /**
      * Shut down MAGE
      *
      * When setting `hard` to true, MAGE will not try to complete current I/O
      * operations and exit immediately; you should avoid using `hard` unless there
      * are no other options available to you.
      *
+     * Note that this will behave similarly to `process.exit`; only the *current*
+     * process will be stopped, not the entire server. To stop the entire server,
+     * see `mage.quit`
+     *
      * @param {number} [exitCode] exit code to use
      * @param {boolean} [hard] If true, exit immediately (exit code will be ignored and set to 1)
      *
      * @memberOf Mage
      */
-    quit(exitCode?: number, hard?: boolean) : never;
+    exit(exitCode?: number, hard?: boolean) : never;
 
     // deprecated
     // fatalError(...args: any[]): never;


### PR DESCRIPTION
  * Renamed `mage.quit` to `mage.exit`
  * Created a new `mage.quit` function that forwards the exit
    request to the master process.

Requires #151
Fixes #140