### PR TITLE
Pluggable service discovery engines

### DIFF
--- a/lib/serviceDiscovery/index.js
+++ b/lib/serviceDiscovery/index.js
@@ -1,11 +1,7 @@
-var mage = require('../mage');
+var mage = require('lib/mage');
 
 var config = mage.core.config.get(['server', 'serviceDiscovery']) || {};
-var engine;
-
-if (config.engine) {
-	engine = require('./engines/' + config.engine);
-}
+var registeredEngines = {};
 
 
 exports.listPeerDependencies = function () {
@@ -15,6 +11,23 @@ exports.listPeerDependencies = function () {
 	};
 };
 
+exports.registerEngine = function (name, mod) {
+	registeredEngines[name] = mod;
+};
+
+exports.getEngine = function () {
+	if (!config || !config.engine) {
+		return null;
+	}
+
+	var engine = registeredEngines[config.engine];
+
+	if (!engine) {
+		engine = registeredEngines[config.engine] = require('./engines/' + config.engine);
+	}
+
+	return engine;
+};
 
 /**
  * Instantiate the service discovery engine and return a light wrapper around the service type the user wants to
@@ -26,6 +39,8 @@ exports.listPeerDependencies = function () {
  */
 
 exports.createService = function (name, type) {
+	var engine = exports.getEngine();
+
 	if (!engine) {
 		throw new Error('No service discovery engine has been configured.');
 	}
@@ -35,5 +50,5 @@ exports.createService = function (name, type) {
 
 
 exports.isEnabled = function () {
-	return !!engine;
+	return !!exports.getEngine();
 };

--- a/mage.ts
+++ b/mage.ts
@@ -1251,6 +1251,10 @@ declare interface IMageCore {
      */
     serviceDiscovery: {
         /**
+         * Register a discovery engine
+         */
+        registerEngine(name: string, mod: mage.core.IServiceDiscoveryEngine)
+        /**
          * Create a service instance
          *
          * Service instances can be used to announce services as well
@@ -2204,6 +2208,14 @@ declare namespace mage {
          * @extends {Logger}
          */
         interface ILogger extends Logger {}
+
+        /**
+         * IServiceDiscoveryEngine defines the structure for pluggable
+         * service discovery engines.
+         */
+        interface IServiceDiscoveryEngine {
+            create(name: string, type: any, configuration: any): IService
+        }
 
         /**
          * IService interface


### PR DESCRIPTION
Enable developers to import their own service discovery engines. This will
be the first step towards externalising most of the engine modules
currently in core.