### PR TITLE
incorrect topic size check, check value size

### DIFF
--- a/lib/archivist/index.js
+++ b/lib/archivist/index.js
@@ -730,18 +730,19 @@ function trackSize(topic, index, value) {
 		return;
 	}
 
-	const size = sizeof(value);
+	const size = sizeof(value.data);
 
-	if (maxSizes.error && maxSizes.error >= size) {
+	if (maxSizes.error && size >= maxSizes.error) {
 		const message = `${topic} with index ${JSON.stringify(index)} exceeds maximum size of ${maxSizes.error}`;
 		throw new Error(message);
 	}
 
-	if (maxSizes.warning && maxSizes.warning >= size) {
+	if (maxSizes.warning && size >= maxSizes.warning) {
 		logger.warning.data({
 			topic: topic,
 			index: index,
-			byteSize: size
+			byteSize: size,
+			maxAllowed: maxSizes.warning
 		}).log('Topic value size warning');
 	}
 }


### PR DESCRIPTION
We were checking the size of a VaultValue, which
would cause sizeof to tight-loop because of circular
dependencies.

The checks for size were reversed.