### PR TITLE
serviceDiscovery: do not mess with the IP order

### DIFF
--- a/docs-sources/includes/_Clustering.md
+++ b/docs-sources/includes/_Clustering.md
@@ -87,6 +87,10 @@ server:
     serviceDiscovery:
         engine: zookeeper
         options:
+            # The interface to announce the IP for. By default, all
+            # IP are announced
+            interface: eth0
+
             # List of available ZooKeeper nodes (comma-separated)
             hosts: "192.168.1.12:2181,192.168.3.18:2181"
 

--- a/lib/serviceDiscovery/engines/consul/index.js
+++ b/lib/serviceDiscovery/engines/consul/index.js
@@ -5,9 +5,10 @@ const os = require('os');
 const requirePeer = require('codependency').get('mage');
 const consul = requirePeer('consul');
 
-const mage = require('../../../mage');
+const mage = require('lib/mage');
 const Service = require('../../service').Service;
 const ServiceNode = require('../../node').ServiceNode;
+const helpers = require('../../helpers');
 
 const logger = mage.core.logger.context('serviceDiscovery', 'consul');
 
@@ -34,13 +35,8 @@ class ConsulService extends Service {
 		this.path = ['mage', name, type].join('/');
 
 		// find the first IPv4 in the provided interface
-		const ipInfo = (os.networkInterfaces()[options.interface] || []).filter(v => v.family === 'IPv4')[0];
-
-		if (!ipInfo || !ipInfo.address) {
-			throw new Error(`No valid IPv4 found on interface ${options.interface}`);
-		}
-
-		this._ip = ipInfo.address;
+		// if no interface is defined, pick the first one we can find
+		this._ip = helpers.getAnnounceIps(options.interface)[0];
 		this._consul = consul(this.options.consul);
 
 		this._services = {};

--- a/lib/serviceDiscovery/engines/zookeeper/index.js
+++ b/lib/serviceDiscovery/engines/zookeeper/index.js
@@ -1,7 +1,7 @@
 var util = require('util');
 var Service = require('../../service').Service;
 var ServiceNode = require('../../node').ServiceNode;
-var mage = require('../../../mage');
+var mage = require('lib/mage');
 var requirePeer = require('codependency').get('mage');
 var zooKeeper = requirePeer('node-zookeeper-client');
 var logger = mage.core.logger.context('zookeeper');
@@ -176,7 +176,7 @@ ZooKeeperService.prototype.reset = function () {
  */
 ZooKeeperService.prototype.announce = function (port, metadata, cb) {
 	var that = this;
-	var ips = helpers.getAnnounceIps();
+	var ips = helpers.getAnnounceIps(this.options.interface);
 	var id = helpers.generateId(port);
 
 	this.announcing = [port, metadata];

--- a/lib/serviceDiscovery/helpers.js
+++ b/lib/serviceDiscovery/helpers.js
@@ -8,35 +8,95 @@ const interfaces = os.networkInterfaces();
 const ifaceNames = Object.keys(interfaces);
 
 /**
- * Builds a list of every announce-able IP on the server
+ * Chech if the list is empty
  *
- * @returns {string} The ip list
- * @todo Support from env variables?
+ * @param {*} addresses
+ * @param {*} errorMessage
  */
-exports.getAnnounceIps = memoizee(function () {
-	const announceIps = [];
+function assertNotEmpty(addresses, errorMessage) {
+	if (addresses.length === 0) {
+		throw Error(errorMessage);
+	}
+}
 
-	for (var i = 0; i < ifaceNames.length; i++) {
-		var addresses = interfaces[ifaceNames[i]];
-
-		for (var j = 0; j < addresses.length; j++) {
-			var address = addresses[j];
-
-			// skip anything that doesn't interest us
-			if (address.internal) {
-				continue;
-			}
-
-			announceIps.push(address.address);
-		}
+/**
+ * Add all valid IP to an existing list of IP
+ *
+ * @param {*} addresses
+ * @param {*} announced
+ * @param {*} useInternalAddresses
+ */
+function pushIps(addresses, announced, useInternalAddresses) {
+	if (!useInternalAddresses) {
+		addresses = addresses.filter((address) => address.internal === false);
 	}
 
-	return announceIps.sort();
+	addresses = addresses
+		.filter((address) => address.family === 'IPv4')
+		.map((address) => address.address);
+
+	return announced.concat(addresses);
+}
+
+/**
+ * Return all valid IP for a single interface
+ *
+ * @param {*} ifaceName
+ */
+function getAnnouncedIpsForInterface(ifaceName) {
+	const addresses = interfaces[ifaceName];
+
+	if (!addresses) {
+		throw new Error('Interface ' + ifaceName + ' could not be found');
+	}
+
+	const announced = pushIps(addresses, [], true);
+	assertNotEmpty(announced, 'Interface ' + ifaceName + ' does not define any IP addresses');
+
+	return announced;
+}
+
+/**
+ * Builds a list of IP. If ifaceName is not set, we return
+ * all public IP of the host (essentially, excluding localhost).
+ *
+ * @returns {string} The ip list
+ */
+exports.getAnnounceIps = memoizee(function (ifaceName) {
+	// If the interface is specified, we may want to specify localhost
+	if (ifaceName) {
+		return getAnnouncedIpsForInterface(ifaceName);
+	}
+
+	const announced = ifaceNames.reduce((announced, name) => pushIps(interfaces[name], announced, false), []);
+	assertNotEmpty(announced, 'Could not find any valid IP addresses');
+
+	// Note: the list of IP **MUST** stay in the order received by
+	// `os.networkInterfaces()`; otherwise, running MAGE on a Docker Swarm
+	// will break in some cases.
+	//
+	// This is due to the fact that interfaces have *two* IP addresses:
+	//
+	//   - One being the IP being used for communication on the overlay network
+	//   - One being used locally for local routing on the local swarm node
+	//
+	// Connecting to that second interface results in MMRP and other services relying
+	// on service discovery to essentially connect to themselves.
+	return announced;
 });
 
+/**
+ * Generate a unique ID based of a signature generated
+ * from the list of IP found on this host.
+ *
+ * @param {*} port
+ */
 exports.generateId = function (port) {
 	const generator = crypto.createHmac('sha256', 'secret');
-	exports.getAnnounceIps().forEach((ip) => generator.update(ip));
+	exports
+		.getAnnounceIps()
+		.sort()
+		.forEach((ip) => generator.update(ip));
 
 	const id = generator.digest('hex').substring(0, 16) + ':' + port;
 	return id;


### PR DESCRIPTION
Changing the IP order breaks how clustering works on Docker Swarm.

This is due to the fact that interfaces have *two* IP addresses:

  - One being the IP being used for communication on the overlay network
  - One being used locally for local routing on the local swarm node

Connecting to that second interface results in MMRP and
other services relying on service discovery to essentially connect
to themselves.

I also took the opportunity to uniformize how Zookeeper and Consul
work (or at least how they select the IP to use, and allowing
similar configuration).