### PR TITLE
npx-based project creation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -41,9 +41,8 @@ Install
 ```bash
 # Replace my-gameserver with how you wish to name your game
 export NODE_ENV=development
-npm install mage --create --prefix my-gameserver
+npx mage create my-gameserver
 cd my-gameserver
-npm run develop
 ```
 
 Then follow the indications on screen as they appear.
@@ -53,9 +52,8 @@ Then follow the indications on screen as they appear.
 ```powershell
 # Replace my-gameserver with how you wish to name your game
 set-item env:NODE_ENV=development
-npm install mage --create --prefix my-gameserver
+npx mage create my-gameserver
 cd my-gameserver
-npm run develop
 ```
 
 Then follow the indications on screen as they appear.
@@ -66,7 +64,7 @@ Optionally, you may also create a TypeScript project. Simply
 add the `--typescript` flag to the previous `npm` command.
 
 ```shell
-npm install mage --create --prefix my-gameserver --typescript
+npx mage create my-gameserver --typescript
 ```
 
 See Also

--- a/bin/mage
+++ b/bin/mage
@@ -1,5 +1,10 @@
 #!/usr/bin/env node
 
+// Executed when running npx mage create
+if (process.argv[2] === 'create') {
+	return require('../scripts/create.js');
+}
+
 const prettyjson = require('prettyjson');
 const chalk = require('chalk');
 const path = require('path');

--- a/docs-sources/includes/_Installation.md
+++ b/docs-sources/includes/_Installation.md
@@ -27,12 +27,14 @@ whenever you start up the game.
 > Replace my-gameserver with how you wish to name your game
 
 ```shell
-npm install mage --create --prefix my-gameserver
+# Note: use npx, not npm!
+npx mage create my-gameserver
 cd my-gameserver
 ```
 
 ```powershell
-npm install mage --create --prefix my-gameserver
+# Note: use npx, not npm!
+npx mage create my-gameserver
 cd my-gameserver
 ```
 
@@ -55,12 +57,13 @@ the end of the line.
 ### As a TypeScript project
 
 ```shell
-npm install mage --create --typescript --prefix my-gameserver
+# Note: use npx, not npm!
+npx mage create my-gameserver --typescript
 cd my-gameserver
 ```
 
 ```powershell
-npm install mage --create --typescript --prefix my-gameserver
+npx mage create my-gameserver --typescript
 cd my-gameserver
 ```
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "test:unit:filter": "npm run test:unit -- --grep",
     "test:unit-rebuild": "npm rebuild && npm run test:unit",
     "test": "run-s test:lint test:unit test:security",
-    "postinstall": "node ./scripts/install.js",
     "preversion": "npm run docs:build && git add ./docs",
     "report:coveralls": "istanbul cover _mocha --root lib --include-all-sources --report lcovonly --dir coveralls -- ./test/index.js && cat ./coveralls/lcov.info | coveralls && rm -rf ./coveralls",
     "report:coverage": "istanbul cover _mocha --root lib --include-all-sources --report html --dir coverage-report -- ./test/index.js",

--- a/scripts/template-rules/default.js
+++ b/scripts/template-rules/default.js
@@ -4,27 +4,11 @@ var pathResolve = require('path').resolve;
 var pathJoin = require('path').join;
 var rl = require('../lib/readline.js');
 
-var magePath = process.cwd();
-var appPath = pathResolve(magePath, '../..');
+var magePath = pathResolve(__dirname, '../..');
+var appPath = process.cwd();
 
 var magePackage = require(pathJoin(magePath, 'package.json'));
-var npmArgs = JSON.parse(process.env.npm_config_argv);
-
-// Note: the following will NOT work
-// with NPM versions; mage@1.1.1 would break
-// not only here, but because template files
-// will hard-code the version as repo#version
-// (note the hash)
-var MAGE_REPO = npmArgs.remain[0];
-var MAGE_VERSION = magePackage.version;
-var MAGE_PACKAGE_VERSION = magePackage.version;
-
-if (MAGE_REPO.indexOf('#') !== -1 || MAGE_REPO.indexOf('/') !== -1) {
-	MAGE_PACKAGE_VERSION = MAGE_REPO;
-} else if (MAGE_REPO.indexOf('@') !== -1) {
-	MAGE_PACKAGE_VERSION = MAGE_REPO.substring(MAGE_REPO.indexOf('@') + 1);
-}
-
+var MAGE_PACKAGE_VERSION = magePackage._from;
 var replacements = {};
 
 function getVar(varName, required) {
@@ -59,8 +43,6 @@ replacements = {
 	APP_LICENSE: 'Private',
 	APP_REPO: '',
 	APP_CLIENTHOST_EXPOSE: '',
-	MAGE_REPO: MAGE_REPO,
-	MAGE_VERSION: MAGE_VERSION,
 	MAGE_PACKAGE_VERSION: MAGE_PACKAGE_VERSION,
 	MAGE_NODE_VERSION: (magePackage.engines && magePackage.engines.node) ? magePackage.engines.node : '',
 	ENV_USER: process.env.USER


### PR DESCRIPTION
This solves a bug with the current TypeScript template caused by
package-lock.json not containing the additional packages
listed in the template's package.json, thus ending up removing
those packages the next time you run `npm install` on the newly created
project.

It also uses the new `npx` command, which reduces the size of the
command.