### PR TITLE
Make user command cache optional

### DIFF
--- a/docs-sources/includes/_Modules.md
+++ b/docs-sources/includes/_Modules.md
@@ -228,6 +228,39 @@ we will return an error on the next access to the user command's `state`
 (which will in turn ensure that execution is interrupted), but manual operations
 unrelated to `state` may still complete.
 
+## Request caching
+
+```shell
+curl -X POST http://127.0.0.1:8080/game/players.checkStats?queryId=1 \
+--data-binary @- << EOF
+[{"key":"be20d767-4067-40d6-92dc-c52067b7d21e:lMftdnXxEFbP3ctq","name":"mage.session"}]
+{}
+EOF
+```
+
+```powershell
+ Invoke-RestMethod -Method Post -Uri "http://127.0.0.1:8080/game/players.checkStats?queryId=1" -Body '[{"key":"be20d767-4067-40d6-92dc-c52067b7d21e:lMftdnXxEFbP3ctq","name":"mage.session"}]
+{}' | ConvertTo-Json
+```
+
+By default, responses to requests from authenticated users which
+contain a numerical identifier in the will be automatically cached;
+this is so to avoid double-execution when the client disconnects before
+the response could be sent and the client wishes to retry.
+
+This comes handy for most operations (trades, purchases and so on),
+but may be undesirable in some circumstances (when you serve computed
+static data or static data stored in the database).
+
+> lib/modules/players/checkStats.js
+
+```javascript
+exports.cache = false;
+```
+
+To disable this behavior, simply set `cache` to false
+in your user command's definition.
+
 ## Using async/await (Node 7.6+)
 
 <aside class="notice">

--- a/lib/commandCenter/commandCenter.js
+++ b/lib/commandCenter/commandCenter.js
@@ -244,7 +244,8 @@ CommandCenter.prototype.setupUserCommand = function (modName, cmdName, cmd) {
 		// for external wrapper libraries which may be using the rest
 		// operator
 		params: cmd.params || params,
-		isAsync: isAsync
+		isAsync: isAsync,
+		cache: cmd.cache !== false
 	};
 };
 
@@ -517,6 +518,7 @@ CommandCenter.prototype.buildParamList = function (cmdInfoModParams, cmdParams) 
  * @param {Object}   cmd        A command object.
  * @param {string}   cmd.name   The name of the command.
  * @param {Object}   cmd.params A key/value map of parameter names and their values.
+ * @param {boolean}  cmd.cache  Whether to cache the user command's output (default: true)
  * @param {Session}  [session]  An optional Session instance.
  * @param {Object}   [metaData] Optional meta data that will be merged into state.data.
  * @param {Function} cb
@@ -725,6 +727,16 @@ CommandCenter.prototype.executeBatch = function (acceptedEncodings, batch, query
 		return durationSec * 1000;
 	}
 
+	function isCachedCommand(cmd) {
+		const cmdInfo = that.getCommandInfo(cmd.name);
+
+		if (!cmdInfo) {
+			return false;
+		}
+
+		return cmdInfo.cache;
+	}
+
 	// process the header
 
 	processBatchHeader(state, batch, function (error) {
@@ -742,28 +754,17 @@ CommandCenter.prototype.executeBatch = function (acceptedEncodings, batch, query
 		// try to load a previously cached response to this query
 
 		that.responseCache.get(state, queryId, function (error, options, content) {
+			let cacheContent = [];
 			if (!error && options && content) {
-				// successful cache retrieval, return instantly
-
-				logger.warning
-					.data({
-						batch: batch.commandNames,
-						session: session ? session.getFullKey() : null,
-						durationMsec: duration(),
-						options: options,
-						dataSize: content.length
-					})
-					.log('Re-sending command response');
-
-				return cb(null, content, options);
+				cacheContent = JSON.parse(content);
 			}
 
 			// start executing commands and build a serialized output response
 
-			function respond(options, content) {
+			function respond(options, content, cache) {
 				// cache the response
 
-				var cached = that.responseCache.set(state, queryId, options, content);
+				var cached = that.responseCache.set(state, queryId, options, cache);
 
 				// send the response back to the client
 
@@ -788,9 +789,18 @@ CommandCenter.prototype.executeBatch = function (acceptedEncodings, batch, query
 
 			// recursively runs each command, until done, then calls respond
 
-			function runCommand(output, cmdIndex) {
+			function runCommand(output, cache, cmdIndex) {
 				var cmd = batch.commands[cmdIndex];
 				if (cmd) {
+					if (cacheContent.length !== 0 && isCachedCommand(cmd)) {
+						logger.warning
+							.data({ cmd: cmd.cmdName })
+							.log('Re-sending cached command response');
+
+						output += (output ? ',' : '[') + cacheContent.shift();
+						return setImmediate(runCommand, output, cache, cmdIndex + 1);
+					}
+
 					return that.executeCommand(cmd, session, metaData, function (error, response) {
 						if (error) {
 							// should never happen
@@ -803,15 +813,26 @@ CommandCenter.prototype.executeBatch = function (acceptedEncodings, batch, query
 							headerEvents = null;
 						}
 
-						output += (output ? ',' : '[') + serializeCommandResult(response);
+						const serializedResponse = serializeCommandResult(response);
+						output += (output ? ',' : '[') + serializedResponse;
 
-						setImmediate(runCommand, output, cmdIndex + 1);
+						if (isCachedCommand(cmd)) {
+							cache += (cache ? ',' : '[') + JSON.stringify(serializedResponse);
+						}
+
+						setImmediate(runCommand, output, cache, cmdIndex + 1);
 					});
 				}
 
 				// close the output JSON array
 
 				output += ']';
+
+				if (cache === '') {
+					cache = '[]';
+				} else {
+					cache += ']';
+				}
 
 				// turn results array into a reportable response (possibly gzipped)
 
@@ -820,22 +841,22 @@ CommandCenter.prototype.executeBatch = function (acceptedEncodings, batch, query
 				};
 
 				if (!shouldCompress(output, acceptedEncodings)) {
-					return respond(options, output);
+					return respond(options, output, cache);
 				}
 
 				return compress(output, function (error, compressed) {
 					if (error) {
 						// error during compression, send the original
-						respond(options, output);
+						respond(options, output, cache);
 					} else {
 						options.encoding = 'gzip';
 
-						respond(options, compressed);
+						respond(options, compressed, cache);
 					}
 				});
 			}
 
-			runCommand('', 0);
+			runCommand('', '', 0);
 		});
 	});
 };

--- a/lib/commandCenter/responseCache.js
+++ b/lib/commandCenter/responseCache.js
@@ -1,4 +1,4 @@
-var mage = require('../mage');
+var mage = require('lib/mage');
 var logger = mage.core.logger.context('responseCache');
 
 


### PR DESCRIPTION
User commands may now be configured to
not cache requests.