### PR TITLE
Remove Node 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ before_install:
   - if [[ "$TRAVIS_NODE_VERSION" == "4" ]]; then npm install -g npm@3; fi
 
 script:
+  - travis_retry npm run test:lint
+  - travis_retry npm run test:security
   - travis_retry npm run report:coveralls
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ dist: trusty
 
 language: node_js
 node_js:
-  - 4
   - 6
   - 7
   - 8
@@ -22,7 +21,7 @@ node_js:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install zmq; fi
-  - if [[ "$TRAVIS_NODE_VERSION" == "4" ]]; then npm install -g npm@3; fi
+  - npm install -g npm@latest
 
 script:
   - travis_retry npm run test:lint

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@ environment:
     - nodejs_version: '8'
     - nodejs_version: '7'
     - nodejs_version: '6'
-    - nodejs_version: '4'
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "resolved": "https://registry.npmjs.org/@types/commander/-/commander-2.9.1.tgz",
       "integrity": "sha1-1ORkQluvRoW9Sd0jO+Ed6cAMB4Q=",
       "requires": {
-        "@types/node": "8.0.28"
+        "@types/node": "8.5.5"
       }
     },
     "@types/fs-extra": {
@@ -18,7 +18,7 @@
       "integrity": "sha512-o2qkg/J2LWK+sr007+KFBBOrxzxpr9kiP0gMFC75gQJXhUn/E3pQA0kSVdxrQ3lf+rOwsRnuH0wnR5MNTotEKg==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.28"
+        "@types/node": "8.5.5"
       }
     },
     "@types/glob": {
@@ -28,7 +28,7 @@
       "dev": true,
       "requires": {
         "@types/minimatch": "2.0.29",
-        "@types/node": "8.0.28"
+        "@types/node": "8.5.5"
       }
     },
     "@types/handlebars": {
@@ -62,9 +62,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.0.28",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.28.tgz",
-      "integrity": "sha512-HupkFXEv3O3KSzcr3Ylfajg0kaerBg1DyaZzRBBQfrU3NN1mTBRE7sCveqHwXLS5Yrjvww8qFzkzYQQakG9FuQ=="
+      "version": "8.5.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.5.tgz",
+      "integrity": "sha512-JRnfoh0Ll4ElmIXKxbUfcOodkGvcNHljct6mO1X9hE/mlrMzAx0hYCLAD7sgT53YAY1HdlpzUcV0CkmDqUqTuA=="
     },
     "@types/shelljs": {
       "version": "0.7.4",
@@ -73,7 +73,7 @@
       "dev": true,
       "requires": {
         "@types/glob": "5.0.32",
-        "@types/node": "8.0.28"
+        "@types/node": "8.5.5"
       }
     },
     "JSV": {
@@ -338,7 +338,7 @@
         "string": "3.3.3",
         "through2-sink": "1.0.0",
         "through2-spy": "1.2.0",
-        "tough-cookie": "2.3.2"
+        "tough-cookie": "2.3.3"
       },
       "dependencies": {
         "debug": {
@@ -443,10 +443,10 @@
         "char-spinner": "1.0.1",
         "condense-whitespace": "1.0.0",
         "default-user-agent": "1.0.0",
-        "errno": "0.1.5",
+        "errno": "0.1.6",
         "extend": "3.0.1",
         "http-equiv-refresh": "1.0.0",
-        "humanize-duration": "3.12.0",
+        "humanize-duration": "3.12.1",
         "is-stream": "1.1.0",
         "is-string": "1.0.4",
         "limited-request-queue": "2.0.0",
@@ -1187,9 +1187,9 @@
       "integrity": "sha1-V9He2h1ryBYisRinX+a1p9NPbYg="
     },
     "errno": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.5.tgz",
-      "integrity": "sha512-tv2H+e3KBnMmNRuoVG24uorOj3XfYo+/nJJd07PUISRr0kaMKQKL5kyD+6ANXk1ZIIsvbORsjvHnCfC4KIc7uQ==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
+      "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
       "dev": true,
       "requires": {
         "prr": "1.0.1"
@@ -1611,6 +1611,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "statuses": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+          "dev": true
         }
       }
     },
@@ -1691,6 +1697,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "statuses": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+          "dev": true
         }
       }
     },
@@ -2198,7 +2210,7 @@
         "depd": "1.1.1",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
-        "statuses": "1.3.1"
+        "statuses": "1.4.0"
       },
       "dependencies": {
         "setprototypeof": {
@@ -2221,9 +2233,9 @@
       }
     },
     "humanize-duration": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.12.0.tgz",
-      "integrity": "sha512-Hnx+whbZRWv2SQnGolrPk+Q20khpkF4hRWTRbldcJx8F0cJQAAo3YaV7+5P6OqssBonI8zN9aZ7Fixs3kWLAhw==",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.12.1.tgz",
+      "integrity": "sha512-Eu68Xnq5C38391em1zfVy8tiapQrOvTNTlWpax9smHMlEEUcudXrdMfXMoMRyZx4uODowYgi1AYiMzUXEbG+sA==",
       "dev": true
     },
     "iconv-lite": {
@@ -2335,9 +2347,9 @@
       "dev": true
     },
     "is-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -2732,7 +2744,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "lazy-cache": {
@@ -2944,7 +2956,7 @@
       "integrity": "sha1-IREFD5qQbgqi1ypOwPAInHhyb48=",
       "requires": {
         "bindings": "1.3.0",
-        "nan": "2.7.0"
+        "nan": "2.8.0"
       }
     },
     "merge-descriptors": {
@@ -3144,9 +3156,9 @@
       }
     },
     "nan": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -3245,7 +3257,7 @@
             "qs": "6.4.0",
             "safe-buffer": "5.1.1",
             "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
+            "tough-cookie": "2.3.3",
             "tunnel-agent": "0.6.0",
             "uuid": "3.1.0"
           }
@@ -3639,7 +3651,7 @@
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.28"
+        "@types/node": "8.5.5"
       }
     },
     "parseurl": {
@@ -4119,7 +4131,7 @@
         "oauth-sign": "0.8.2",
         "qs": "6.3.2",
         "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
+        "tough-cookie": "2.3.3",
         "tunnel-agent": "0.4.3",
         "uuid": "3.1.0"
       },
@@ -4336,6 +4348,12 @@
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
           "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
           "dev": true
+        },
+        "statuses": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+          "dev": true
         }
       }
     },
@@ -4526,9 +4544,9 @@
       }
     },
     "statuses": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
       "dev": true
     },
     "stream-combiner": {
@@ -4858,9 +4876,9 @@
       }
     },
     "tough-cookie": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "dev": true,
       "requires": {
         "punycode": "1.4.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "@types/commander": {
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/@types/commander/-/commander-2.9.1.tgz",
-      "integrity": "sha512-P4s1aEJYjHB1pmS5th4WXQ/NEYykK1FmCFJL+NIrDCptWs2DIS/SsVjmaubvcWZ17VzlG+CwiAv52ghkfkepWA==",
+      "integrity": "sha1-1ORkQluvRoW9Sd0jO+Ed6cAMB4Q=",
       "requires": {
         "@types/node": "8.0.28"
       }
@@ -367,7 +367,7 @@
     "bindings": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+      "integrity": "sha1-s0b27PapX1qBXFg5/HzbIlAvHtc="
     },
     "block-stream": {
       "version": "0.0.9",
@@ -610,7 +610,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
     },
     "cli": {
@@ -1865,7 +1865,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
       "dev": true
     },
     "gauge": {
@@ -1968,7 +1968,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -1981,7 +1981,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
       "dev": true
     },
     "globby": {
@@ -2133,7 +2133,7 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
       "dev": true
     },
     "htmlparser2": {
@@ -2378,7 +2378,7 @@
     "is-my-json-valid": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
-      "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
+      "integrity": "sha1-WoRnd+LCYg0eaRBOXToDsfYIjxE=",
       "dev": true,
       "requires": {
         "generate-function": "2.0.0",
@@ -2651,7 +2651,7 @@
     "json-parse-better-errors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
-      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
+      "integrity": "sha1-UBg80bLSUnXeBp6ecbRnrJ6rlzo=",
       "dev": true
     },
     "json-schema": {
@@ -2982,7 +2982,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -3382,7 +3382,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
@@ -4013,7 +4013,7 @@
     "read-package-json": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.12.tgz",
-      "integrity": "sha512-m7/I0+tP6D34EVvSlzCtuVA4D/dHL6OpLcn2e4XVP5X57pCKGUy1JjRSBVKHWpB+vUU91sL85h84qX0MdXzBSw==",
+      "integrity": "sha1-aOpF+Ys3QctuEK47vUKmBQJqaVE=",
       "dev": true,
       "requires": {
         "glob": "7.1.2",
@@ -4047,7 +4047,7 @@
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
       "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
@@ -4133,7 +4133,7 @@
         "uuid": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+          "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
           "dev": true
         }
       }
@@ -4288,7 +4288,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
       "dev": true
     },
     "safe-timers": {
@@ -4592,7 +4592,7 @@
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
       "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
@@ -4678,7 +4678,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -5205,7 +5205,7 @@
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"


### PR DESCRIPTION
When using versions of NPM too old to understand `package-lock.json` (or stick to its rules, I'm not entirely sure), they will end up installing dependencies of dependencies of versions that are not consistent with our package-lock file.

That can in turn mean that node modules with known vulnerabilities get installed, and we would like to avoid that. For that reason I had to remove Node 4 from our test matrix. Not all our current dependency versions are ready for Node 9 yet, so I have not been able to add Node 9 to the matrix.

That means our test matrix will become:

- Node 6
- Node 7
- Node 8