### PR TITLE
boot errors: make sure to exit

### DIFF
--- a/bin/mage
+++ b/bin/mage
@@ -70,4 +70,9 @@ if (!app.boot) {
 	process.exit(-1);
 }
 
-app.boot();
+app.boot((error) => {
+	if (error) {
+		logError(`Failed to load MAGE application: ${error.stack || error}`);
+		app.exit(1, true);
+	}
+});

--- a/lib/processManager/processManager.js
+++ b/lib/processManager/processManager.js
@@ -549,7 +549,14 @@ processManager.initialize = function (mageInstance, mageLogger, pmConfig) {
 	process.on('uncaughtException', function (error) {
 		logger.emergency('Uncaught exception:', error);
 
-		if (shutdownOnError) {
+		/**
+		 * Exit if:
+		 *
+		 *   1. If the process manager is not initialized (or the variable is not set)
+		 *   2. The current runstate is not 'running' (either setup or quitting)
+		 *   3. We shut down on error according to the configuration
+		 */
+		if (!mage || mage.getRunState() !== 'running' || shutdownOnError) {
 			mage.exit(-1);
 		}
 	});


### PR DESCRIPTION
Always exit on error when we are not in a running state (during startup,
shutdown, etc).