### PR TITLE
Documentation improvement on supported Node versions.

### DIFF
--- a/docs-sources/includes/_Requirements.md
+++ b/docs-sources/includes/_Requirements.md
@@ -3,18 +3,22 @@
 ## Node.js
 
 <aside class="notice">
-We recommend using version 4 since it is an LTS version
+MAGE always supports the "Active LTS" (Long Term Support) versions of Node.js.
+We recommend using the most recent Active LTS version, but we always try to support the Current Release as well.
+
+You can see what the LTS and Current versions are in the Node.js
+<a href="https://github.com/nodejs/Release#release-schedule">release schedule</a>.
 </aside>
 
 ```shell
-nvm install 4
-nvm use 4
+nvm install 8
+nvm use 8
 ```
 
 ```powershell
 # You will need to provide the specific version to install and use
-Install-NodeVersion v4.8.2
-Set-NodeVersion v4.8.2
+Install-NodeVersion v8.9.4
+Set-NodeVersion v8.9.4
 ```
 
 Node.js (or Node) is essentially JavaScript for servers, and the MAGE platform has been built on it.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "types": "./mage.ts",
   "engines": {
-    "node": "^4 || ^6 || ^7 || ^8",
+    "node": "^6 || ^7 || ^8",
     "typescript": "^2.2"
   },
   "scripts": {


### PR DESCRIPTION
This advocates the use of the most current LTS version and links to the LTS schedule.
Since we no longer support Node 4, this PR also removes it from the "engines" field in package.json.

Sidenote: it seems some documentation was altered, but never rebuilt. Since a rebuild of docs took place, they are a part of this PR.

Closes #207 