### PR TITLE
Remove unused function msgServer.getMsgStreamUrl()

### DIFF
--- a/lib/msgServer/index.js
+++ b/lib/msgServer/index.js
@@ -146,18 +146,6 @@ exports.getPublicConfig = function (baseUrl) {
 };
 
 
-/**
- * Returns the URL to the message stream (optionally based on the Host header passed to it)
- *
- * @param {Object} [headers]
- * @returns {string}
- */
-
-exports.getMsgStreamUrl = function (headers) {
-	return mage.core.httpServer.getBaseUrl(headers) + (cfgMsgStream.route || '');
-};
-
-
 // Message Server API for cluster-wide user-to-user communication
 // --------------------------------------------------------------
 

--- a/mage.ts
+++ b/mage.ts
@@ -1118,20 +1118,12 @@ declare interface IMageCore {
         getClusterId(): string;
 
         /**
-         * Retreive the configuration used by this Message
+         * Retrieve the configuration used by this Message
          * Server instance
          *
          * @returns {*}
          */
         getPublicConfig(): any;
-
-        /**
-         * Get the URL to use to connect to this Message
-         * Stream's instance
-         *
-         * @returns {string}
-         */
-        getMsgStreamUrl(): string;
 
         /**
          * Send a message to a remote Message Server instance


### PR DESCRIPTION
This API was used in the past by build systems, but has long been replaced by `getPublicConfig`.