### PR TITLE
Add index to archivist.sca

### DIFF
--- a/lib/archivist/index.js
+++ b/lib/archivist/index.js
@@ -694,7 +694,15 @@ Archivist.prototype.scan = function (topic, partialIndex, options, cb) {
 		}
 
 		const queries = indexes.map((index) => ({ topic, index }));
-		this.mget(queries, options, cb);
+		this.mget(queries, options, (error, data) => {
+			// Add index to data
+			// Eg. [ [{ userId: 1 }, { name: "foo" }], [{ userId: 2 }, { name: "bar" }] ]
+			const indexedData = data.map((obj, idx) => {
+				return [queries[idx].index, obj];
+			});
+
+			cb(indexedData);
+		});
 	});
 };
 


### PR DESCRIPTION
Add index to archivist.scan results.

It changes the actual results:
`[ { name: "foo" }, { name: "bar" } ]`
to:
`[ [{ userId: 1 }, { name: "foo" }], [{ userId: 2 }, { name: "bar" }] ]`