### PR TITLE
Update consul client version supported to 0.30.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "xpipe": "1.0.5"
   },
   "optionalPeerDependencies": {
-    "consul": "~0.29.0",
+    "consul": "~0.30.0",
     "graylog2": "~0.1.3",
     "mysql": "^2.4.1",
     "couchbase": "^2.1.6",


### PR DESCRIPTION
The previous version of the consul client supported was `0.29.0`. However, this version does not work with the latest version of the consul server. For example, `agent.check.pass` now needs to use a `put` request and a `get` request can't be used anymore (see [enforced http verbs](https://www.consul.io/docs/upgrade-specific.html#http-verbs-are-enforced-in-many-http-apis) and [changes on the client](https://github.com/silas/node-consul/compare/0.29.0...master#diff-7047ceb28f7475e0b32a2f822b2d053f)).