### PR TITLE
Better couchbase errors

### DIFF
--- a/docs-sources/includes/_Archivist.md
+++ b/docs-sources/includes/_Archivist.md
@@ -167,9 +167,8 @@ config:
         hosts: [ "localhost:8091" ]
 
         # optional
-        # do not specify this if you don't need it,
-        # otherwise it could fail to init the client
-        user: Administrator
+        # do not specify this if your bucket does not have a password,
+        # otherwise it will fail to open the bucket
         password: "password"
 
         # optional

--- a/docs-sources/includes/_Archivist.md
+++ b/docs-sources/includes/_Archivist.md
@@ -167,6 +167,8 @@ config:
         hosts: [ "localhost:8091" ]
 
         # optional
+        # do not specify this if you don't need it,
+        # otherwise it could fail to init the client
         user: Administrator
         password: "password"
 
@@ -175,6 +177,11 @@ config:
 
         # optional, useful if you share a bucket with other applications
         prefix: "bob/"
+
+        # optional, can use any option specified in https://developer.couchbase.com/documentation/server/5.1/sdk/nodejs/client-settings.html#topic_pkk_vhn_qv__d397e189
+        options:
+          # usefull to debug network errors (eg. authentication errors)
+          detailed_errcodes: 1
 
     # options only used with archivist:create
     create:

--- a/lib/archivist/vaults/couchbase/index.js
+++ b/lib/archivist/vaults/couchbase/index.js
@@ -123,46 +123,30 @@ CouchbaseVault.prototype.setup = function (cfg, cb) {
 	// Create cluster configuration instance and connect initiating bucket handshake
 	var cluster = this.cluster = new couchbase.Cluster(connstr.stringify(cfg.options));
 
-	var _client = null;
-	Object.defineProperties(this, {
-		client: {
-			get: function () {
-				if (_client === null || _client.connected === false) {
-					_client = cluster.openBucket(cfg.options.bucket, cfg.options.password);
-
-					// Setup event handlers
-					_client.on('connect', function () {
-						logger.notice('Connected to Couchbase bucket:', cfg.options.bucket);
-					});
-					_client.on('error', function (error) {
-						// Create new object from error otherwise the message field is not print
-						// This is caused by the JSON.stringify in the logger (see https://github.com/mage/mage/blob/master/lib/loggingService/writers/terminal.js#L170)
-						// Could be solved with https://stackoverflow.com/questions/18391212/is-it-not-possible-to-stringify-an-error-using-json-stringify
-						const errorJson = {
-							code: error.code,
-							value: getCouchbaseErrorValue(error.code),
-							message: error.message
-						};
-
-						logger.emergency('Couchbase server error for bucket ', cfg.options.bucket, ':', errorJson);
-					});
-
-					// Enable n1ql by feeding in query hosts. this is required for now since they have not
-					// implemented the automatic configuration part of this.
-					if (cfg.options.qhosts) {
-						_client.enableN1ql(cfg.options.qhosts);
-					}
-
-					// Create pass-through transcoder functions
-					_client.setTranscoder(couchbaseHelpers.encoder, couchbaseHelpers.decoder);
-				}
-
-				return _client;
-			}
+	this.client = cluster.openBucket(cfg.options.bucket, cfg.options.password, (err) => {
+		if (err) {
+			return cb(err);
 		}
-	});
 
-	return cb();
+		// Setup event handlers
+		this.client.on('connect', function () {
+			logger.notice('Connected to Couchbase bucket:', cfg.options.bucket);
+		});
+		this.client.on('error', function (error) {
+			logger.emergency('Couchbase server error for bucket ', cfg.options.bucket, ':', error);
+		});
+
+		// Enable n1ql by feeding in query hosts. this is required for now since they have not
+		// implemented the automatic configuration part of this.
+		if (cfg.options.qhosts) {
+			this.client.enableN1ql(cfg.options.qhosts);
+		}
+
+		// Create pass-through transcoder functions
+		this.client.setTranscoder(couchbaseHelpers.encoder, couchbaseHelpers.decoder);
+
+		return cb();
+	});
 };
 
 

--- a/lib/archivist/vaults/couchbase/index.js
+++ b/lib/archivist/vaults/couchbase/index.js
@@ -44,21 +44,22 @@ function wash(obj) {
 }
 
 /**
- * Get an error code's value
- * Eg. 16 -> networkError
+ * Replace the Couchbase error.code number with its value
+ * Eg. {code: 16} -> {code: networkError}
  * See all available values here: https://github.com/couchbase/couchnode/blob/master/lib/errors.js
  *
- * @param {number} code The error code
- * @returns {string} The error code's value
+ * @param {CouchbaseError} error The error
+ * @returns {CouchbaseError} The transformed CouchbaseError
  */
-function getCouchbaseErrorValue(code) {
+function getCouchbaseError(error) {
 	for (const [key, value] of Object.entries(couchbase.errors)) {
-		if (value === code) {
-			return key;
+		if (value === error.code) {
+			error.code = key;
+			break;
 		}
 	}
 
-	return null;
+	return error;
 }
 
 
@@ -125,7 +126,7 @@ CouchbaseVault.prototype.setup = function (cfg, cb) {
 
 	this.client = cluster.openBucket(cfg.options.bucket, cfg.options.password, (err) => {
 		if (err) {
-			return cb(err);
+			return cb(getCouchbaseError(err));
 		}
 
 		// Setup event handlers
@@ -133,7 +134,7 @@ CouchbaseVault.prototype.setup = function (cfg, cb) {
 			logger.notice('Connected to Couchbase bucket:', cfg.options.bucket);
 		});
 		this.client.on('error', function (error) {
-			logger.emergency('Couchbase server error for bucket ', cfg.options.bucket, ':', error);
+			logger.emergency('Couchbase server error for bucket ', cfg.options.bucket, ':', getCouchbaseError(error));
 		});
 
 		// Enable n1ql by feeding in query hosts. this is required for now since they have not
@@ -197,11 +198,11 @@ CouchbaseVault.prototype.get = function (key, options, cb) {
 		// to return undefined in that case.
 
 		if (error) {
-			if (error.code === 13 || error.message !== 'No such key') {
+			if (error.code === couchbase.errors.keyNotFound || error.message !== 'No such key') {
 				return cb();
 			}
 
-			return cb(error);
+			return cb(getCouchbaseError(error));
 		}
 
 		var value = result.value.value;
@@ -243,7 +244,7 @@ CouchbaseVault.prototype.set = function (key, data, options, cb) {
 	}
 
 	this.client.upsert(key, data, wash(options), function (error) {
-		cb(error);
+		cb(getCouchbaseError(error));
 	});
 };
 
@@ -424,7 +425,7 @@ CouchbaseVault.prototype.createDatabase = function (cb) {
 	var clusterManager = cluster.manager(createBucket.adminUsername, createBucket.adminPassword);
 	clusterManager.listBuckets(function (error, buckets) {
 		if (error) {
-			return cb(error);
+			return cb(getCouchbaseError(error));
 		}
 
 		var bucketExists = false;
@@ -479,7 +480,7 @@ CouchbaseVault.prototype.dropDatabase = function (cb) {
 	var clusterManager = this.cluster.manager(createBucket.adminUsername, createBucket.adminPassword);
 	clusterManager.listBuckets(function (error, buckets) {
 		if (error) {
-			return cb(error);
+			return cb(getCouchbaseError(error));
 		}
 
 		var bucketExists = false;

--- a/lib/archivist/vaults/couchbase/index.js
+++ b/lib/archivist/vaults/couchbase/index.js
@@ -43,6 +43,24 @@ function wash(obj) {
 	return obj;
 }
 
+/**
+ * Get an error code's value
+ * Eg. 16 -> networkError
+ * See all available values here: https://github.com/couchbase/couchnode/blob/master/lib/errors.js
+ *
+ * @param {number} code The error code
+ * @returns {string} The error code's value
+ */
+function getCouchbaseErrorValue(code) {
+	for (const [key, value] of Object.entries(couchbase.errors)) {
+		if (value === code) {
+			return key;
+		}
+	}
+
+	return null;
+}
+
 
 /**
  * Instantiates the CouchbaseVault (only done through the create() factory function)
@@ -117,7 +135,16 @@ CouchbaseVault.prototype.setup = function (cfg, cb) {
 						logger.notice('Connected to Couchbase bucket:', cfg.options.bucket);
 					});
 					_client.on('error', function (error) {
-						logger.emergency('Couchbase server error for bucket:', cfg.options.bucket, error);
+						// Create new object from error otherwise the message field is not print
+						// This is caused by the JSON.stringify in the logger (see https://github.com/mage/mage/blob/master/lib/loggingService/writers/terminal.js#L170)
+						// Could be solved with https://stackoverflow.com/questions/18391212/is-it-not-possible-to-stringify-an-error-using-json-stringify
+						const errorJson = {
+							code: error.code,
+							value: getCouchbaseErrorValue(error.code),
+							message: error.message
+						};
+
+						logger.emergency('Couchbase server error for bucket ', cfg.options.bucket, ':', errorJson);
 					});
 
 					// Enable n1ql by feeding in query hosts. this is required for now since they have not

--- a/lib/loggingService/LogEntry.js
+++ b/lib/loggingService/LogEntry.js
@@ -10,25 +10,25 @@ var IncomingMessage = require('http').IncomingMessage;
 var ServerResponse = require('http').ServerResponse;
 
 function serializeError(error) {
-	// the stack trace and other error information will be moved into the data object
-
-	// turn the stack string into an array, stripped from its noisy whitespace
-
-	var stack = error.stack && error.stack.split(/\s*\n\s*at\s+/);
-	if (!stack || stack.length <= 1) {
-		return error;
-	}
-
-	// remove the first line: "Error: name", leaving only stack frames
-
-	stack.shift();
-
 	// assign all the data to the data object (custom errors may have some)
 	var data = Object.assign({
 		code: error.code,
 		type: error.name,
 		message: error.message || undefined
 	}, error);
+
+	// the stack trace and other error information will be moved into the data object
+
+	// turn the stack string into an array, stripped from its noisy whitespace
+
+	var stack = error.stack && error.stack.split(/\s*\n\s*at\s+/);
+	if (!stack || stack.length <= 1) {
+		return data;
+	}
+
+	// remove the first line: "Error: name", leaving only stack frames
+
+	stack.shift();
 
 	// reformat the stack
 


### PR DESCRIPTION
Add some modifications to Couchbase errors management:
- CouchbaseError.code is replaced with it's [value](https://github.com/couchbase/couchnode/blob/master/lib/errors.js)
- The client is init at application boot rather than at first operation
- Add documentation for CouchbaseVault.options.options which automatically set [connection options](https://developer.couchbase.com/documentation/server/5.1/sdk/nodejs/client-settings.html#topic_pkk_vhn_qv__d397e189)

Fixes #221 