### PR TITLE
Couchbase error helper: error may be null

### DIFF
--- a/lib/archivist/vaults/couchbase/index.js
+++ b/lib/archivist/vaults/couchbase/index.js
@@ -52,6 +52,10 @@ function wash(obj) {
  * @returns {CouchbaseError} The transformed CouchbaseError
  */
 function getCouchbaseError(error) {
+	if (!error) {
+		return;
+	}
+
 	for (const [key, value] of Object.entries(couchbase.errors)) {
 		if (value === error.code) {
 			error.code = key;


### PR DESCRIPTION
The helper must check whether the received value is an object
before attempting to read its attribute.