### PR TITLE
Add default ttl for topics

### DIFF
--- a/docs-sources/includes/_Archivist.md
+++ b/docs-sources/includes/_Archivist.md
@@ -297,8 +297,28 @@ exports.player = {
 Topics are essentially Archivist datatypes; they define which vault(s)
 to use for storage, the key structure for accessing data, and so on.
 
-In this example, we simply specify a new topic, called items, in which we will be
-identifying by itemId.
+In this example, we simply specify a new topic, called player, in which we will be
+identifying by userId.
+
+### Add an expiration time
+
+In your topic config, you can specify a `ttl` to make your data expires after a certain amount of time.
+
+`ttl` should be a string matching one of the following formats:
+
+- days: "[num]d"
+- hours: "[num]h"
+- minutes: "[num]m"
+- seconds: "[num]s"
+
+> Add an expiration time
+
+```javascript
+exports.player = {
+  // ...
+  ttl: '1m' // Expire the data after 1 minute
+};
+```
 
 ## Store & retrieve topics
 

--- a/lib/archivist/configuration.js
+++ b/lib/archivist/configuration.js
@@ -456,6 +456,14 @@ function registerTopicConfig(topic, cfg) {
 	topicConfig.afterLoad = cfg.afterLoad;
 	topicConfig.beforeDistribute = cfg.beforeDistribute;
 
+	// store ttl
+
+	if (cfg.ttl) {
+		const timeCodeToSec = mage.core.helpers.timeCodeToSec;
+		topicConfig.ttl = timeCodeToSec(cfg.ttl);
+	}
+
+
 	// store the topic config
 
 	topicConfigs[topic] = topicConfig;

--- a/lib/archivist/index.js
+++ b/lib/archivist/index.js
@@ -194,6 +194,15 @@ function attemptReadFromVault(state, vault, value, cb) {
 	});
 }
 
+function getTopicExpirationTime(topic) {
+	const config = configuration.getTopicConfig(topic);
+	if (config.ttl) {
+		return Date.now() / 1000 + config.ttl;
+	}
+
+	return null;
+}
+
 
 // Archivist instances manage access to vaults
 // -------------------------------------------
@@ -774,6 +783,11 @@ Archivist.prototype.set = function (topic, index, data, mediaType, encoding, exp
 	trackSize(topic, index, value);
 
 	value.set(mediaType, data, encoding);
+
+	if (!expirationTime) {
+		expirationTime = getTopicExpirationTime(topic);
+	}
+
 	value.touch(expirationTime);
 };
 
@@ -788,6 +802,10 @@ Archivist.prototype.del = function (topic, index) {
 // OPERATION: Touch
 
 Archivist.prototype.touch = function (topic, index, expirationTime) {
+	if (!expirationTime) {
+		expirationTime = getTopicExpirationTime(topic);
+	}
+
 	this._requestVaultValue(topic, index).touch(expirationTime);
 };
 

--- a/test/archivist/index.js
+++ b/test/archivist/index.js
@@ -2,4 +2,5 @@ describe('archivist', function () {
 	require('./encodings');
 	require('./vaults');
 	require('./operations');
+	require('./ttl');
 });

--- a/test/archivist/ttl.js
+++ b/test/archivist/ttl.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const assert = require('assert');
+const sinon = require('sinon');
+
+const Archivist = require('lib/archivist').Archivist;
+const configuration = require('lib/archivist/configuration');
+
+const archivist = new Archivist();
+
+const topic = 'user';
+const index = 'userId';
+const ttl = 1;
+
+describe('ttl', () => {
+	let _requestVaultValueStub = null;
+	let getConfigurationSub = null;
+	let getTopicConfigSub = null;
+	let touchSpy = null;
+
+	before(() => {
+		touchSpy = sinon.spy();
+		_requestVaultValueStub = sinon.stub(Archivist.prototype, '_requestVaultValue').returns({
+			touch: touchSpy,
+			set: () => {}
+		});
+		getConfigurationSub = sinon.stub(configuration, 'getConfiguration').callsFake(() => {
+			return {};
+		});
+		getTopicConfigSub = sinon.stub(configuration, 'getTopicConfig').callsFake(() => {
+			return {
+				ttl: ttl
+			};
+		});
+		sinon.spy();
+	});
+
+	after(() => {
+		_requestVaultValueStub.restore();
+		getConfigurationSub.restore();
+		getTopicConfigSub.restore();
+	});
+
+	afterEach(() => {
+		_requestVaultValueStub.resetHistory();
+		getConfigurationSub.resetHistory();
+		getTopicConfigSub.resetHistory();
+		touchSpy.resetHistory();
+	});
+
+	it('[archivist.set] use ttl config', () => {
+		archivist.set(topic, { [index]: 5 });
+		assert(touchSpy.called, 'vault.touch should be called');
+		assert(touchSpy.calledOnce, 'vault.touch should be called only once');
+		assert(touchSpy.calledWithExactly(Date.now() / 1000 + ttl));
+	});
+
+	it('[archivist.set] does not use ttl config if expirationTime in params', () => {
+		archivist.set(topic, { [index]: 5 }, {}, 'application/json', 'utf8', 5);
+		assert(touchSpy.called, 'vault.touch should be called');
+		assert(touchSpy.calledOnce, 'vault.touch should be called only once');
+		assert(touchSpy.calledWithExactly(5));
+	});
+});


### PR DESCRIPTION
In lib/archivist/index.js, the user can specify a ttl string (See timeCodeToSec in lib/helpers/helpers.js for format) to expire the topic at a given time.

Resolves #163