### PR TITLE
details on vault setup errors, create migrates

### DIFF
--- a/lib/archivist/configuration.js
+++ b/lib/archivist/configuration.js
@@ -707,7 +707,19 @@ exports.openVaults = function (_logger, cb) {
 				return callback();
 			}
 
-			vault.open(callback);
+			vault.open((err) => {
+				if (err) {
+					logger.alert
+					.details('Early errors may mean one of the following:')
+					.details('  1. The remote server is down or inaccessible')
+					.details('  2. You need to run `npm run archivist:create` to create')
+					.details('     and configure storage for your vault backend')
+					.details('See error data for more details.')
+					.log(`Failed to set up vault ${vaultName}`);
+				}
+
+				return callback(err);
+			});
 		},
 		cb
 	);

--- a/lib/archivist/vaults/file/index.js
+++ b/lib/archivist/vaults/file/index.js
@@ -103,14 +103,9 @@ FileVault.prototype.open = function (cb) {
 	var logger = this.logger;
 	var that = this;
 
-	fs.stat(this.filePath, function (err, stats) {
+	fs.stat(this.filePath, (err, stats) => {
 		if (err) {
-			if (err.code === 'ENOENT') {
-				logger.warning('Path', this.filePath, 'not found, skipping value expiration.');
-				return cb();
-			}
-
-			logger.emergency('Error while performing a stat on:', this.filePath, err);
+			logger.emergency('Error while performing a stat on:', this.filePath);
 			return cb(err);
 		}
 
@@ -119,7 +114,7 @@ FileVault.prototype.open = function (cb) {
 			return cb(new Error('Path not a directory'));
 		}
 
-		that.checkMeta(function (error) {
+		that.checkMeta((error) => {
 			if (error) {
 				return cb(error);
 			}

--- a/lib/archivist/vaults/mysql/index.js
+++ b/lib/archivist/vaults/mysql/index.js
@@ -88,7 +88,13 @@ MysqlVault.prototype.open = function (cb) {
 
 	this.pool = this.mysql.createPool(this.config);
 
-	setImmediate(cb);
+	this.pool.getConnection((err) => {
+		if (err) {
+			this.logger.emergency('Failed to open mysql connection', this.config);
+		}
+
+		return cb(err);
+	});
 };
 
 MysqlVault.prototype.close = function () {

--- a/lib/tasks/archivist-create.js
+++ b/lib/tasks/archivist-create.js
@@ -1,14 +1,11 @@
 var async = require('async');
+var migrate = require('./migrate');
 
 
 exports.setup = function (mage, options, cb) {
 	async.series([
-		function (callback) {
-			mage.core.loggingService.setup(callback);
-		},
-		function (callback) {
-			mage.core.archivist.setup(callback);
-		}
+		(callback) => mage.core.loggingService.setup(callback),
+		(callback) => mage.core.archivist.setup(callback)
 	], cb);
 };
 
@@ -37,7 +34,7 @@ exports.start = function (mage, options, cb) {
 			return cb(error);
 		}
 
-		cb(null, { shutdown: true });
+		migrate.start(mage, options, cb);
 	});
 };
 

--- a/lib/tasks/archivist-migrate.js
+++ b/lib/tasks/archivist-migrate.js
@@ -3,15 +3,9 @@ var async = require('async');
 
 exports.setup = function (mage, options, cb) {
 	async.series([
-		function (callback) {
-			mage.core.loggingService.setup(callback);
-		},
-		function (callback) {
-			mage.core.archivist.setup(callback);
-		},
-		function (callback) {
-			mage.core.archivist.openVaults(callback);
-		}
+		(callback) => mage.core.loggingService.setup(callback),
+		(callback) => mage.core.archivist.setup(callback),
+		(callback) => mage.core.archivist.openVaults(callback)
 	], cb);
 };
 


### PR DESCRIPTION
Error log will hint the user that they need to run `archivist:create`
to setup up the storage.

`archivist:create` now implies `archivist:migrate`.

Fixes #104