### PR TITLE
Fix FileVault expiration time

### DIFF
--- a/lib/archivist/vaults/file/index.js
+++ b/lib/archivist/vaults/file/index.js
@@ -35,7 +35,9 @@ function safeExt(ext) {
 
 
 function applyTTL(fileVault, filenameWithoutExt, expirationSeconds) {
-	clearTimeout(fileVault._timers[filenameWithoutExt]);
+	if (fileVault._timers[filenameWithoutExt]) {
+		fileVault._timers[filenameWithoutExt].clear();
+	}
 
 	var now = Date.now();
 	var expirationMilliseconds = expirationSeconds * 1000;
@@ -139,7 +141,7 @@ FileVault.prototype.close = function () {
 	this.logger.verbose('Closing vault:', this.name);
 
 	for (var filenameWithoutExt in this._timers) {
-		clearTimeout(this._timers[filenameWithoutExt]);
+		this._timers[filenameWithoutExt].clear();
 	}
 
 	this._timers = {};
@@ -438,8 +440,10 @@ FileVault.prototype.delMeta = function (filenameWithoutExt, cb) {
 
 		// Remove the timer if it had one.
 
-		clearTimeout(that._timers[filenameWithoutExt]);
-		delete that._timers[filenameWithoutExt];
+		if (that._timers[filenameWithoutExt]) {
+			that._timers[filenameWithoutExt].clear();
+			delete that._timers[filenameWithoutExt];
+		}
 
 		cb(error);
 	});


### PR DESCRIPTION
FileVault timers were not cleared correctly, so data was deleted even if a new TTL was set.

Fixes #233