### PR TITLE
Update ecmascript support

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -7,6 +7,9 @@
     mocha: true
     node: true
     es6: true
+  parserOptions:
+    ecmaVersion: 8
+    sourceType: "module"
   rules:
     no-bitwise: 0
     camelcase:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ dist: trusty
 
 language: node_js
 node_js:
-  - 6
   - 8
   - 9
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@ environment:
   matrix:
     - nodejs_version: '9'
     - nodejs_version: '8'
-    - nodejs_version: '6'
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/docs-sources/includes/_Requirements.md
+++ b/docs-sources/includes/_Requirements.md
@@ -4,6 +4,10 @@
 
 <aside class="warning">
 MAGE only supports node from version 8.x
+We recommend using the most recent Active LTS version, but we always try to support the Current Release as well.
+
+You can see what the LTS and Current versions are in the Node.js
+<a href="https://github.com/nodejs/Release#release-schedule">release schedule</a>.
 </aside>
 
 ```shell

--- a/docs-sources/includes/_Requirements.md
+++ b/docs-sources/includes/_Requirements.md
@@ -2,12 +2,8 @@
 
 ## Node.js
 
-<aside class="notice">
-MAGE always supports the "Active LTS" (Long Term Support) versions of Node.js.
-We recommend using the most recent Active LTS version, but we always try to support the Current Release as well.
-
-You can see what the LTS and Current versions are in the Node.js
-<a href="https://github.com/nodejs/Release#release-schedule">release schedule</a>.
+<aside class="warning">
+MAGE only supports node from version 8.x
 </aside>
 
 ```shell

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "types": "./mage.ts",
   "engines": {
-    "node": "^6 || ^7 || ^8 || ^9",
+    "node": "^8 || ^9",
     "typescript": "^2.2"
   },
   "scripts": {


### PR DESCRIPTION
Supports only node >= v8.x.

This will allow us to use ES8 features in the engine such as async/await.