### PR TITLE
Fix mysql vault setup

### DIFF
--- a/lib/archivist/vaults/mysql/index.js
+++ b/lib/archivist/vaults/mysql/index.js
@@ -80,15 +80,18 @@ MysqlVault.prototype.setup = function (cfg, cb) {
 		this.config = cfg.options;
 	}
 
+	this.pool = this.mysql.createPool(this.config);
+
 	setImmediate(cb);
 };
 
 MysqlVault.prototype.open = function (cb) {
 	this.logger.verbose('Opening vault:', this.name);
 
-	this.pool = this.mysql.createPool(this.config);
-
-	setImmediate(cb);
+	// Create one connection
+	this.pool.getConnection((err) => {
+		return cb(err);
+	});
 };
 
 MysqlVault.prototype.close = function () {


### PR DESCRIPTION
Mysql pool was created in MysqlVault.open but it should be created in MysqlVault.setup as it's not doing any connection.
Also, MysqlVault.createDatabase and MysqlVault.dropDatabase need the pool when MysqlVault.open is not called.