### PR TITLE
Remove ServiceNode.isLocal

### DIFF
--- a/lib/msgServer/index.js
+++ b/lib/msgServer/index.js
@@ -533,7 +533,7 @@ function setupDiscovery() {
 
 		// relays connect to other relays, and clients connect to their own master process
 
-		mmrpNode.relayUp(uri, data, announced.isLocal());
+		mmrpNode.relayUp(uri, data);
 	});
 
 	// relays should disconnect from other relays when they disappear

--- a/lib/msgServer/mmrp/index.js
+++ b/lib/msgServer/mmrp/index.js
@@ -252,24 +252,24 @@ MmrpNode.prototype.disconnect = function (uri, clusterId) {
  * @param {string} clusterId
  */
 
-MmrpNode.prototype.relayUp = function (uri, data, isLocal, cb) {
+MmrpNode.prototype.relayUp = function (uri, data, cb) {
 	const clusterId = data.clusterId;
 
 	// Log entry
 
 	const verbose = logger.verbose.data({
 		uri,
-		isLocal,
 		localClusterId: this.clusterId,
 		receivedClusterId: clusterId
 	});
 
 	const connect = () => this.connect(uri, data, cb);
+	const sameCluster = clusterId === this.clusterId;
 
 	// Local workers connect to the local interface created by the master
 
 	if (!this.isRelay) {
-		if (this.isClient && clusterId === this.clusterId) {
+		if (this.isClient && sameCluster) {
 			verbose.log('client connecting to own relay');
 			return connect();
 		}
@@ -278,22 +278,14 @@ MmrpNode.prototype.relayUp = function (uri, data, isLocal, cb) {
 		return callMeMaybe(cb);
 	}
 
-	// relays ignores its own uri
-	//
-	// When a server dies unexpectedly, it may respawn before
-	// service discovery has cleaned up the dead node; therefore,
-	// we need service discovery to tell us whether it believes the
-	// node to be local or not, instead of relying on the
-	// clusterId as we do in many other places in this code.
-
-	if (isLocal) {
-		verbose.log('local node was announced as up (ignoring).');
+	if (sameCluster) {
+		verbose.log('same cluster relay node was announced as up (ignoring).');
 		return callMeMaybe(cb);
 	}
 
 	// connect to a remote relay (generally a remote master process)
 
-	verbose.log('attempting to connect');
+	verbose.log('relay connecting to client');
 	connect();
 };
 

--- a/lib/serviceDiscovery/node.js
+++ b/lib/serviceDiscovery/node.js
@@ -2,8 +2,6 @@
 
 const os = require('os');
 const net = require('net');
-const mage = require('../mage');
-const logger = mage.core.logger.context('serviceDiscovery');
 const Netmask = require('netmask').Netmask;
 
 // prebuilt list of local ips
@@ -88,29 +86,6 @@ ServiceNode.prototype.getIp = function (version, network) {
 	}
 
 	return null;
-};
-
-/**
- * Returns whether this node is running on the local machine or not, based on the announced ips
- *
- * @returns {boolean}
- */
-ServiceNode.prototype.isLocal = function () {
-	const ip = this.addresses[0];
-
-	if (!ip) {
-		logger.warning.data(this).log('No IP was found/resolved for that service');
-		return false;
-	}
-
-	const version = 'IPv' + net.isIP(ip);
-	if (version === 'IPv0') {
-		logger.warning.data(this).log('Invalid IP announced');
-		return false;
-	}
-
-	// if we find it in the local ips, then we are good!
-	return localIps[version].indexOf(ip) !== -1;
 };
 
 exports.ServiceNode = ServiceNode;

--- a/test/msgServer/mmrp.js
+++ b/test/msgServer/mmrp.js
@@ -107,12 +107,12 @@ describe('MMRP', function () {
 			network.clients.forEach(function (client) {
 				client.relayUp(createUri(network.relay.routerPort), {
 					clusterId: network.relay.clusterId
-				}, true);
+				});
 			});
 
 			network.relay.relayUp(createUri(network.relay.routerPort), {
 				clusterId: network.relay.clusterId
-			}, true);
+			});
 		}
 
 		it('instantiates', function () {
@@ -195,7 +195,7 @@ describe('MMRP', function () {
 				relays.forEach(function (peer) {
 					relay.relayUp(createUri(peer.routerPort), {
 						clusterId: peer.clusterId
-					}, relay.clusterId === peer.clusterId);
+					});
 				});
 			});
 		}
@@ -373,7 +373,7 @@ describe('MMRP', function () {
 					peer.relayUp(createUri(relay.routerPort), {
 						clusterId: relay.clusterId,
 						timestamp: Date.now()
-					}, peer.clusterId === relay.clusterId);
+					});
 				});
 			});
 		}


### PR DESCRIPTION
ServiceNode.isLocal was implemented to prevent a server to re-register itself in the service discovery if it crashes and restarts. However, it's not used anymore as an other PR fixed it.