### PR TITLE
Fix SingleService service discovery

### DIFF
--- a/lib/serviceDiscovery/engines/single/index.js
+++ b/lib/serviceDiscovery/engines/single/index.js
@@ -20,6 +20,9 @@ function SingleService(name, type, options) {
 	this.type = type;
 	this.options = options;
 
+	// this is the base path we will use to announce this service
+	this.baseAnnouncePath = ['/mage', this.name, this.type].join('/');
+
 	this.services = {};
 	this.isBrowsing = false;
 
@@ -28,7 +31,7 @@ function SingleService(name, type, options) {
 	// If the master receive a browse event,
 	// it should send all the services the sender of the event
 	if (mage.core.processManager.isMaster) {
-		messenger.on('browse', function (data, workerId) {
+		messenger.on(this.baseAnnouncePath, function (data, workerId) {
 			Object.keys(that.services).forEach(function (key) {
 				messenger.send(workerId, 'up', that.services[key]);
 			});
@@ -99,7 +102,7 @@ SingleService.prototype.discover = function () {
 
 	if (mage.core.processManager.isWorker) {
 		// Tell the master to send the updated list of services
-		messenger.send('master', 'browse');
+		messenger.send('master', this.baseAnnouncePath);
 	}
 
 	// Announce to itself services already registered


### PR DESCRIPTION
SingleService did not take into account type and name of the service. Thus, 2 services with a different name and type would communicate. It fixes one part of the issue mage/mage-module-shard#2.