### PR TITLE
Add options in typescript template tsconfig.json

### DIFF
--- a/scripts/templates/typescript-project/tsconfig.json
+++ b/scripts/templates/typescript-project/tsconfig.json
@@ -11,6 +11,8 @@
     "removeComments": true,
     "sourceMap": true,
     "inlineSources": true,
-    "inlineSourceMap": false
+    "inlineSourceMap": false,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
   }
 }


### PR DESCRIPTION
Add experimentalDecorators and emitDecoratorMetadata options in typescript template tsconfig.json because in most of the cases mage-validator is used, and it needs theses options.