### PR TITLE
Fix doc api build crash

### DIFF
--- a/docs-sources/includes/_Events.md
+++ b/docs-sources/includes/_Events.md
@@ -97,7 +97,7 @@ you may want to send an event after a certain amount of time, or once something 
 in the database. To do so, you will need to create your own State of that. You will also need
 to make sure to manually close that state.
 
-For more information, please read the [State API documentation](./api/interfaces/_mage_d_.mage.core.istate.html).
+For more information, please read the [State API documentation](./api/interfaces/mage.core.istate.html).
 
 ## Broadcasting events
 

--- a/docs-sources/includes/_HTTP.md
+++ b/docs-sources/includes/_HTTP.md
@@ -7,7 +7,7 @@ of the following:
   2. Serve service status files (or content)
   3. Proxy requests to a remote server through MAGE
 
-To this end, MAGE provides to developers an [API](./api/interfaces/_mage_d_.imagecore.html#httpserver) that will allow you
+To this end, MAGE provides to developers an [API](./api/interfaces/imagecore.html#httpserver) that will allow you
 to do such things.
 
 ## Cross-Origin Resource Sharing (CORS)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,12 +2,11 @@
   "compilerOptions": {
     "module": "commonjs",
     "moduleResolution": "node",
-    "baseUrl": "../",
-    "typeRoots": [
-        "../"
-    ],
-    "types": [],
     "isolatedModules": true,
     "noEmit": true
-  }
+  },
+  "include": [
+    "./lib/**/*.ts",
+    "./*.ts"
+  ]
 }


### PR DESCRIPTION
docs:build:api caused an out of memory because it was resolving all the .ts files from the repository (eg. node_modules).