### PR TITLE
Rename server.cluster config to server.workers

### DIFF
--- a/docs-sources/includes/_Production.md
+++ b/docs-sources/includes/_Production.md
@@ -22,7 +22,7 @@ DEVELOPMENT_MODE=false npm start
 
 The "server" entry in the configuration must be set up properly. That *probably* means:
 
-  * `cluster` should be set to a number to indicate a worker count, or even better, to `true` (meaning
+  * `workers` should be set to a number to indicate a worker count, or even better, to `true` (meaning
     that as many workers will be spawned as the CPU has cores).
   * `serviceDiscovery.engine` should be appropriately selected for this environment.
   * `mmrp` must be set up to allow all MAGE servers to communicate with each other on the network.

--- a/lib/processManager/config.yaml
+++ b/lib/processManager/config.yaml
@@ -1,2 +1,2 @@
-cluster: 0
+workers: 0
 shutdownGracePeriod: 15

--- a/lib/processManager/index.js
+++ b/lib/processManager/index.js
@@ -3,6 +3,7 @@
  * components to be mocked easily for unit testing.
  */
 
+var cluster = require('cluster');
 var path = require('path');
 var mage = require('../mage');
 var logger = mage.core.logger.context('processManager');
@@ -16,10 +17,19 @@ mage.core.config.setTopLevelDefault('server', path.join(__dirname, 'config.yaml'
 // Extract relevant configuration
 
 var config = {
-	numberOfWorkers: mage.core.config.get(['server', 'cluster'], false),
+	numberOfWorkers: mage.core.config.get(['server', 'cluster']) || mage.core.config.get(['server', 'workers'], false),
 	shutdownGracePeriod: mage.core.config.get(['server', 'shutdownGracePeriod']),
 	shutdownOnError: mage.core.config.get(['server', 'shutdownOnError'], true)
 };
+
+// Display deprecation message for server.cluster
+// if server.cluster is defined and server.workers is not defined
+// and only on master process to prevent duplicated logs
+if (cluster.isMaster &&
+	mage.core.config.get(['server', 'workers']) === undefined &&
+	mage.core.config.get(['server', 'cluster']) !== undefined) {
+	logger.warning('server.cluster config is deprecated. Please use workers instead');
+}
 
 // Pass the needed components into the state library for normal mage use.
 processManager.initialize(mage, logger, config);

--- a/scripts/templates/javascript-project/config/default.yaml
+++ b/scripts/templates/javascript-project/config/default.yaml
@@ -53,9 +53,9 @@ server:
         detect:
             - longpolling
 
-    # Set cluster to boolean true to have as many workers as this machine has cores, or a number
+    # Set workers to boolean true to have as many workers as this machine has cores, or a number
     # if you want to be more precise.
-    cluster: 1
+    workers: 1
 
     # Shutdown the current worker process when an uncaught exception is
     # caught, and let MAGE restart the process. You will normally

--- a/scripts/templates/javascript-project/config/production.yaml
+++ b/scripts/templates/javascript-project/config/production.yaml
@@ -38,9 +38,9 @@ logging:
 # The server and its place in the network
 
 server:
-    # Set cluster to boolean true to have as many workers as this machine has cores, or a number
+    # Set workers to boolean true to have as many workers as this machine has cores, or a number
     # if you want to be more precise.
-    cluster: true
+    workers: true
 
     # MMRP is the messaging layer between node instances, built on top of ZeroMQ
     mmrp:

--- a/scripts/templates/typescript-project/config/default.yaml
+++ b/scripts/templates/typescript-project/config/default.yaml
@@ -53,9 +53,9 @@ server:
         detect:
             - longpolling
 
-    # Set cluster to boolean true to have as many workers as this machine has cores, or a number
+    # Set workers to boolean true to have as many workers as this machine has cores, or a number
     # if you want to be more precise.
-    cluster: 1
+    workers: 1
 
     # Shutdown the current worker process when an uncaught exception is
     # caught, and let MAGE restart the process. You will normally

--- a/scripts/templates/typescript-project/config/production.yaml
+++ b/scripts/templates/typescript-project/config/production.yaml
@@ -37,9 +37,9 @@ logging:
 # The server and its place in the network
 
 server:
-    # Set cluster to boolean true to have as many workers as this machine has cores, or a number
+    # Set workers to boolean true to have as many workers as this machine has cores, or a number
     # if you want to be more precise.
-    cluster: true
+    workers: true
 
     # MMRP is the messaging layer between node instances, built on top of ZeroMQ
     mmrp:


### PR DESCRIPTION
In MAGE, a cluster is a MAGE instance but server.cluster was used for the number of workers.
Thus, it would be more clear to rename it to server.workers.