### PR TITLE
Can ban user

### DIFF
--- a/lib/commandCenter/commandCenter.js
+++ b/lib/commandCenter/commandCenter.js
@@ -540,6 +540,23 @@ CommandCenter.prototype.executeCommand = function (cmd, session, metaData, cb) {
 		data: metaData
 	});
 
+	if (state.isBanned()) {
+		logger.info.data({
+			app: this.app.name,
+			module: cmdInfo.mod.name,
+			command: cmd.name,
+			user_acl: state.acl
+		});
+
+		return state.error('banned', null, function () {
+			// close the state and send the response
+
+			state.close(function (closeError, response) {
+				cb(null, response);
+			});
+		});
+	}
+
 	// Return an error if the user does not have a sufficient right
 	// level to execute this user command
 	if (!state.canAccess(cmdInfo.mod.acl)) {

--- a/lib/modules/auth/index.js
+++ b/lib/modules/auth/index.js
@@ -10,6 +10,7 @@ hashes.register('hash', require('./hashes/types/Hash'));
 hashes.register('hmac', require('./hashes/types/Hmac'));
 hashes.register('pbkdf2', require('./hashes/types/Pbkdf2'));
 
+const BAN_GROUP = 'banned';
 
 // error classes
 
@@ -218,6 +219,10 @@ exports.login = function (state, username, password, cb) {
 			return cb(error);
 		}
 
+		if (state.isBanned()) {
+			return cb('banned');
+		}
+
 		return cb(null, session);
 	});
 };
@@ -333,3 +338,58 @@ exports.changePassword = function (state, username, newPassword, cb) {
 		});
 	});
 };
+
+/**
+ * Ban a user
+ * @param {*} state
+ * @param {*} username
+ * @param {*} cb Receives (error)
+ */
+exports.ban = function (state, username, cb) {
+	findUser(state, username, function (error, user) {
+		if (error) {
+			return cb(error);
+		}
+
+		if (!user) {
+			return cb(new UserNotFoundError(username));
+		}
+
+		// Already banned
+		if (user.acl.includes(BAN_GROUP)) {
+			return cb(null);
+		}
+
+		// Add ban group to user acl
+		user.acl.push(BAN_GROUP);
+		storeUser(state, user);
+
+		return cb(null);
+	});
+};
+
+/**
+ * Unban a user
+ * @param {*} state
+ * @param {*} username
+ * @param {*} cb Receives (error)
+ */
+exports.unban = function (state, username, cb) {
+	findUser(state, username, function (error, user) {
+		if (error) {
+			return cb(error);
+		}
+
+		if (!user) {
+			return cb(new UserNotFoundError(username));
+		}
+
+		// Remove ban group from user acl
+		user.acl = user.acl.filter((acl) => acl !== BAN_GROUP);
+		storeUser(state, user);
+
+		return cb(null);
+	});
+};
+
+exports.BAN_GROUP = BAN_GROUP;

--- a/lib/state/state.js
+++ b/lib/state/state.js
@@ -13,6 +13,7 @@ var Archivist;
  */
 var NO_DESCRIPTION = 'no description';
 
+const { BAN_GROUP } = require('../modules/auth');
 
  /**
   * StateError class
@@ -206,6 +207,12 @@ State.prototype.canAccess = function (acl) {
 	return false;
 };
 
+/**
+ * Returns is the user is banned
+ */
+State.prototype.isBanned = function () {
+	return this.acl.includes(BAN_GROUP);
+};
 
 /**
  * Set the description for this state

--- a/mage.ts
+++ b/mage.ts
@@ -230,6 +230,10 @@ declare type RegisterCallback = (error: Error|null, userId: string) => void;
 
 declare type ChangePasswordCallback = (error: Error|null) => void;
 
+declare type BanCallback = (error: Error|null) => void;
+
+declare type UnbanCallback = (error: Error|null) => void;
+
 declare interface ILog extends Function {
     /**
      * String(s) to log
@@ -1592,6 +1596,16 @@ declare class Mage extends NodeJS.EventEmitter {
          * Change a user's password.
          */
         changePassword(state: mage.core.IState, username: string, newPassword: string, callback: ChangePasswordCallback): void;
+
+        /**
+         * Ban the user
+         */
+        ban(state: mage.core.IState, username: string, callback: BanCallback): void;
+
+        /**
+         * Unban the user
+         */
+        unban(state: mage.core.IState, username: string, callback: UnbanCallback): void;
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -285,9 +285,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
       "dev": true
     },
     "babel-code-frame": {
@@ -404,15 +404,6 @@
             "ms": "2.0.0"
           }
         }
-      }
-    },
-    "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "dev": true,
-      "requires": {
-        "hoek": "4.2.1"
       }
     },
     "brace-expansion": {
@@ -799,16 +790,16 @@
       "dev": true
     },
     "coveralls": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.0.tgz",
-      "integrity": "sha512-ZppXR9y5PraUOrf/DzHJY6gzNUhXYE3b9D43xEXs4QYZ7/Oe0Gy0CS+IPKWFfvQFXB3RG9QduaQUFehzSpGAFw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.1.tgz",
+      "integrity": "sha512-FAzXwiDOYLGDWH+zgoIA+8GbWv50hlx+kpEJyvzLKOdnIBv9uWoVl4DhqGgyUHpiRjAlF8KYZSipWXYtllWH6Q==",
       "dev": true,
       "requires": {
         "js-yaml": "3.8.4",
         "lcov-parse": "0.0.10",
         "log-driver": "1.2.7",
         "minimist": "1.2.0",
-        "request": "2.85.0"
+        "request": "2.87.0"
       },
       "dependencies": {
         "minimist": {
@@ -838,26 +829,6 @@
         "lru-cache": "4.1.2",
         "shebang-command": "1.2.0",
         "which": "1.3.0"
-      }
-    },
-    "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-      "dev": true,
-      "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "dev": true,
-          "requires": {
-            "hoek": "4.2.1"
-          }
-        }
       }
     },
     "d": {
@@ -1986,18 +1957,6 @@
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
-    "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-      "dev": true,
-      "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
-      }
-    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -2013,12 +1972,6 @@
       "version": "9.12.0",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
       "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
-      "dev": true
-    },
-    "hoek": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
       "dev": true
     },
     "hosted-git-info": {
@@ -2114,7 +2067,7 @@
       "requires": {
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
-        "sshpk": "1.14.1"
+        "sshpk": "1.14.2"
       }
     },
     "humanize-duration": {
@@ -2538,9 +2491,9 @@
       }
     },
     "json-parse-better-errors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
-      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
     "json-schema": {
@@ -3733,7 +3686,7 @@
       "requires": {
         "glob": "7.1.2",
         "graceful-fs": "4.1.11",
-        "json-parse-better-errors": "1.0.1",
+        "json-parse-better-errors": "1.0.2",
         "normalize-package-data": "2.4.0",
         "slash": "1.0.0"
       }
@@ -3812,20 +3765,19 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "request": {
-      "version": "2.85.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
-      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "version": "2.87.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "dev": true,
       "requires": {
         "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
+        "aws4": "1.7.0",
         "caseless": "0.12.0",
         "combined-stream": "1.0.6",
         "extend": "3.0.1",
         "forever-agent": "0.6.1",
         "form-data": "2.3.2",
         "har-validator": "5.0.3",
-        "hawk": "6.0.2",
         "http-signature": "1.2.0",
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
@@ -3835,7 +3787,6 @@
         "performance-now": "2.1.0",
         "qs": "6.5.1",
         "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
         "tough-cookie": "2.3.4",
         "tunnel-agent": "0.6.0",
         "uuid": "3.2.1"
@@ -3903,14 +3854,14 @@
       }
     },
     "retire": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/retire/-/retire-1.6.0.tgz",
-      "integrity": "sha1-hkzZTfu8H/Vn1ftACr7v6Kt8GsE=",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/retire/-/retire-1.6.1.tgz",
+      "integrity": "sha512-ovF0Ped7UModTuHRjOLy6RDWl6uTqPuyOCSYM547aCsu5T/3kIeqGxgapYz+e/ABr0eup0gmqSlch4SlemeTAw==",
       "dev": true,
       "requires": {
         "commander": "2.5.1",
         "read-installed": "4.0.3",
-        "request": "2.85.0",
+        "request": "2.87.0",
         "walkdir": "0.0.7"
       },
       "dependencies": {
@@ -3997,6 +3948,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/safe-timers/-/safe-timers-1.0.1.tgz",
       "integrity": "sha1-40VJ8/d95SLv1dbvfyl0aIl5sMg="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "samsam": {
       "version": "1.3.0",
@@ -4158,15 +4115,6 @@
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
       "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
       "dev": true
-    },
-    "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-      "dev": true,
-      "requires": {
-        "hoek": "4.2.1"
-      }
     },
     "source-map": {
       "version": "0.1.31",
@@ -4706,9 +4654,9 @@
       }
     },
     "sshpk": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
-      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "requires": {
         "asn1": "0.2.3",
@@ -4718,6 +4666,7 @@
         "ecc-jsbn": "0.1.1",
         "getpass": "0.1.7",
         "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
         "tweetnacl": "0.14.5"
       }
     },
@@ -4793,12 +4742,6 @@
         "traverse": "0.6.6",
         "type-name": "2.0.2"
       }
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
   },
   "devDependencies": {
     "broken-link-checker-local": "0.1.1",
-    "coveralls": "3.0.0",
+    "coveralls": "3.0.1",
     "cross-env": "4.0.0",
     "eslint": "3.19.0",
     "eslint-plugin-json": "1.2.0",
@@ -111,7 +111,7 @@
     "mysql": "2.5.4",
     "npm-run-all": "4.0.2",
     "power-assert": "1.4.2",
-    "retire": "1.6.0",
+    "retire": "1.6.1",
     "sinon": "4.5.0",
     "sqlite3": "4.0.0",
     "typedoc": "0.7.0",


### PR DESCRIPTION
Add two methods in auth module:

- `auth.ban`: add ban group acl (constant) to the user
- `auth.unban`: remove ban group acl (constant) from the user

Add unit tests testing the new behaviour.  The only untested path is in `CommandCenter.executeCommand`.

When a user is banned and tries to access a user command or login, it returns a `banned` error.