### PR TITLE
fix: long-polling response timeout

### DIFF
--- a/lib/msgServer/msgStream/transports/http-polling/index.js
+++ b/lib/msgServer/msgStream/transports/http-polling/index.js
@@ -157,8 +157,6 @@ HttpPollingHost.prototype.close = function () {
 HttpPollingHost.prototype.setConnection = function (req, res, query) {
 	logger.verbose('Connection established');
 
-	var that = this;
-
 	this.res = res;
 
 	if (query.confirmIds) {
@@ -175,17 +173,16 @@ HttpPollingHost.prototype.setConnection = function (req, res, query) {
 	// set up heartbeat timeout and premature connection-lost handling
 
 	if (this.timeout) {
-		req.setTimeout(this.timeout, function () {
-			that._sendHeartbeat();
-		});
+		req.setTimeout(this.timeout, () => this._sendHeartbeat());
+		res.setTimeout(this.timeout, () => this._sendHeartbeat());
 	}
 
 	// "close" indicates that the underlying connection was terminated before response.end() was
 	// called or able to flush.
 
-	req.on('close', function () {
+	req.on('close', () => {
 		logger.debug('Client connection disappeared');
-		that._closeConnection();
+		this._closeConnection();
 	});
 };
 


### PR DESCRIPTION
Missing response timeout on long-polling would result in
the connection being interrupted, and the client to
think that a network error occured.