### PR TITLE
mage.core.State: this === mage.core if new missing

### DIFF
--- a/lib/state/state.js
+++ b/lib/state/state.js
@@ -100,6 +100,10 @@ function setFromOpts(state, opts, key, defaultValue) {
  * @param {*} opts
  */
 function State(actorId, session, opts) {
+	if (!this || this.archivist) {
+		throw new Error('`this` context is incorrect, did you forget to use the `new` keyword?');
+	}
+
 	opts = opts || {};
 
 	this.actorId = actorId ? ('' + actorId) : undefined;

--- a/test/state.js
+++ b/test/state.js
@@ -80,6 +80,31 @@ describe('State class', function () {
 	before(() => mod.initialize(fakeMage, logger, FakeArchivist));
 
 	describe('instanciation', function () {
+		it('missing `new` keyword will throw', function () {
+			try {
+				State(); // eslint-disable-line new-cap
+			} catch (error) {
+				return assert(error.message, '`this` context is incorrect, did you forget to use the `new` keyword?');
+			}
+
+			throw new Error('Did not throw');
+		});
+
+		it('missing `new` keyword will throw', function () {
+			const mage = {
+				core: {
+					archivist: {},
+					State: State
+				}
+			};
+			try {
+				mage.core.State(); // eslint-disable-line new-cap
+			} catch (error) {
+				return assert(error.message, '`this` context is incorrect, did you forget to use the `new` keyword?');
+			}
+
+			throw new Error('Did not throw');
+		});
 		it('Without arguments', function () {
 			const state = new State();
 


### PR DESCRIPTION
Consider the following code:

```typescript
const state = mage.core.State();
```

While some linters will pick up on the mistake, others may not, and
the REPL interface will give you no hint that you are doing is wrong.

And what you are doing, is, indeed, terribly wrong:

- Instead of a new instance `this` in State is now equal to
  mage.core
- When we instanciate the object, we create a new Archivist instance:
  this.archivist = new Archivist()
- Which then replaces mage.core.archivist with an **instance** of
  Archivist; from there onward, archivist modules are no longer
  available.
- If you try to properly shut down or CTRL-C, missing API will create an
  emergency shutdown error; the process is now stuck.

JavaScript. Not even once.

The solution is to:

- Make sure `this` is defined
- Make sure `this.archivist` is NOT defined

It's mostly a band-aid, but hopefully this will avoid the majority of
the issues.