### PR TITLE
url.parse: slashesDenoteHost should be false

### DIFF
--- a/lib/httpServer/transports/http/index.js
+++ b/lib/httpServer/transports/http/index.js
@@ -626,7 +626,7 @@ function requestHandler(req, res) {
 	if (isAsterisk) {
 		path = '*';
 	} else {
-		urlInfo = url.parse(req.url, true, true);
+		urlInfo = url.parse(req.url, true);
 		path = safeDecodePath(urlInfo.pathname);
 
 		route = routers.http.get(path);


### PR DESCRIPTION
URL paths should never include a host; therefore, this option is not
needed. Solves an issue where double-slashes prefixed calls would return
404 instead of being properly routed.