### PR TITLE
Check if timer exists before deleting it in memory vault

### DIFF
--- a/lib/archivist/vaults/memory/index.js
+++ b/lib/archivist/vaults/memory/index.js
@@ -133,10 +133,12 @@ MemoryVault.prototype.del = function (trueName, cb) {
 	var timers = this._timers;
 
 	setImmediate(function () {
-		timers[trueName].clear();
+		if (timers[trueName]) {
+			timers[trueName].clear();
+			delete timers[trueName];
+		}
 
 		delete store[trueName];
-		delete timers[trueName];
 
 		cb();
 	});


### PR DESCRIPTION
Tested to fix #274, delete works correctly with no TTL set.