### PR TITLE
Consul improvements

### DIFF
--- a/lib/serviceDiscovery/engines/consul/index.js
+++ b/lib/serviceDiscovery/engines/consul/index.js
@@ -89,20 +89,19 @@ class ConsulService extends Service {
 	announce(port, metadata, cb) {
 		logger.debug(`Announcing service ${this.name} on port ${port}`);
 		this._announces.push({port, metadata});
-		this.session((err, id) => {
+		this.session((err) => {
 			if (err) {
 				return cb(err);
 			}
 
-			const key = [this.path, os.hostname(), process.pid].join('/');
+			const key = [this.path, os.hostname(), helpers.generateId(port)].join('/');
 			this._consul.kv.set({
 				key,
 				value: JSON.stringify({
 					port,
 					ip: this._ip,
 					data: metadata
-				}),
-				acquire: id
+				})
 			}, cb);
 		});
 	}
@@ -242,7 +241,7 @@ class ConsulService extends Service {
 				logger.error.data(err).log(`Failed to renew session ${this._sessionId}`);
 			}
 
-			this._keepaliveTimer = setTimeout(this._keepalive.bind(this, sessionId), this.ttl);
+			this._keepaliveTimer = setTimeout(this._keepalive.bind(this, sessionId), this.ttl / 2);
 		});
 	}
 

--- a/lib/serviceDiscovery/engines/consul/index.js
+++ b/lib/serviceDiscovery/engines/consul/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const async = require('async');
-const os = require('os');
 const requirePeer = require('codependency').get('mage');
 const consul = requirePeer('consul');
 
@@ -94,7 +93,7 @@ class ConsulService extends Service {
 				return cb(err);
 			}
 
-			const key = [this.path, os.hostname(), helpers.generateId(port)].join('/');
+			const key = [this.path, helpers.generateId(port)].join('/');
 			this._consul.kv.set({
 				key,
 				value: JSON.stringify({


### PR DESCRIPTION
* Instead of the PID, use the generated ID for the service so that a crash/restart will reuse the same key instead of creating dupes that will drop off and destroy our sanity as they bring down modules
* Increase rate of Consul session refreshes to half of TTL to ensure they remain alive even with latency spikes
* Don't lock on sessions so a replacement cluster can take over the key safely