### PR TITLE
Use Consul locks to ensure expired services get removed

### DIFF
--- a/lib/serviceDiscovery/engines/consul/index.js
+++ b/lib/serviceDiscovery/engines/consul/index.js
@@ -5,6 +5,7 @@ const requirePeer = require('codependency').get('mage');
 const consul = requirePeer('consul');
 
 const mage = require('lib/mage');
+const MageError = require('../../../mage/MageError');
 const Service = require('../../service').Service;
 const ServiceNode = require('../../node').ServiceNode;
 const helpers = require('../../helpers');
@@ -113,7 +114,10 @@ class ConsulService extends Service {
 					// If we can contact Consul but we can't set the key, there is no 'err'; the
 					// returned result is simply set to false so we need to check for it here
 					if (result === false) {
-						return cb(new Error('Could not set Consul KV for service (likely due to another lock)'));
+						return cb(new MageError({
+							message: 'Could not set Consul KV for service',
+							details: 'Consul was contacted successfully, but the key was unable to be set after deleting existing sessions.  If this persists, check if the Consul KV store is configured correctly.'
+						}));
 					}
 
 					cb(null);

--- a/lib/serviceDiscovery/engines/consul/index.js
+++ b/lib/serviceDiscovery/engines/consul/index.js
@@ -60,7 +60,8 @@ class ConsulService extends Service {
 
 		this._consul.session.create({
 			behavior: 'delete',
-			ttl: `${Math.ceil(this.ttl / 1000)}s`
+			ttl: `${Math.ceil(this.ttl / 1000)}s`,
+			lockdelay: '0s'
 		}, (err, id) => {
 			if (id) {
 				this._sessionId = id.ID;
@@ -88,20 +89,52 @@ class ConsulService extends Service {
 	announce(port, metadata, cb) {
 		logger.debug(`Announcing service ${this.name} on port ${port}`);
 		this._announces.push({port, metadata});
-		this.session((err) => {
+		this.session((err, id) => {
 			if (err) {
 				return cb(err);
 			}
 
 			const key = [this.path, helpers.generateId(port)].join('/');
-			this._consul.kv.set({
-				key,
-				value: JSON.stringify({
-					port,
-					ip: this._ip,
-					data: metadata
-				})
-			}, cb);
+
+			const doSet = () => {
+				this._consul.kv.set({
+					key,
+					value: JSON.stringify({
+						port,
+						ip: this._ip,
+						data: metadata
+					}),
+					acquire: id
+				}, (err, result) => {
+					if (err) {
+						return cb(err);
+					}
+
+					// If we can contact Consul but we can't set the key, there is no 'err'; the
+					// returned result is simply set to false so we need to check for it here
+					if (result === false) {
+						return cb(new Error('Could not set Consul KV for service (likely due to another lock)'));
+					}
+
+					cb(null);
+				});
+			};
+
+			this._consul.kv.get(key, (err, data) => {
+				// If we didn't find it, just set as normal
+				if (err || !data) {
+					return doSet();
+				}
+
+				// Otherwise we have to delete the old session and take over the key for ourselves
+				this._consul.session.destroy(data.Session, (err) => {
+					if (err) {
+						return cb(err);
+					}
+
+					doSet();
+				});
+			});
 		});
 	}
 

--- a/lib/serviceDiscovery/engines/consul/index.js
+++ b/lib/serviceDiscovery/engines/consul/index.js
@@ -116,6 +116,7 @@ class ConsulService extends Service {
 					if (result === false) {
 						return cb(new MageError({
 							message: 'Could not set Consul KV for service',
+							// eslint-disable-next-line max-len
 							details: 'Consul was contacted successfully, but the key was unable to be set after deleting existing sessions.  If this persists, check if the Consul KV store is configured correctly.'
 						}));
 					}


### PR DESCRIPTION
The earlier PR had a hidden bug: the value wasn't being expired properly.  This reintroduces consul locks to fix that issue and automatically takes over the expired key in the event of a fast restart by destroying the old session.